### PR TITLE
Add 'use client' to auth_helpers

### DIFF
--- a/src/react/auth_helpers.tsx
+++ b/src/react/auth_helpers.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import { ReactNode } from "react";
 import { useConvexAuth } from "./ConvexAuthState.js";


### PR DESCRIPTION
Added 'use client' directive to `auth_helpers`, fixes #10 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
