### PR TITLE
Update `ExtractDocument` for current usage

### DIFF
--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -64,15 +64,13 @@ type ExtractFieldPaths<T extends Validator<any, any, any>> =
 
 /**
  * Extract the {@link GenericDocument} within a {@link Validator} and
- * add on the system fields.
+ * add on the system fields (including the  `_id`).
  *
- * This is used within {@link defineTable}.
  * @public
  */
-type ExtractDocument<T extends Validator<any, any, any>> =
-  // Add the system fields to `Value` (except `_id` because it depends on
-  //the table name) and trick TypeScript into expanding them.
-  Expand<SystemFields & T["type"]>;
+type ExtractDocument<TableName extends string, T extends Validator<any, any, any>> =
+  // Add the system fields to `Value` and trick TypeScript into expanding them.
+  Expand<IdField<TableName> & SystemFields & T["type"]>;
 
 /**
  * The configuration for a full text search index.
@@ -542,9 +540,7 @@ export type DataModelFromSchemaDefinition<
       infer VectorIndexes
     >
       ? {
-          // We've already added all of the system fields except for `_id`.
-          // Add that here.
-          document: Expand<IdField<TableName> & ExtractDocument<DocumentType>>;
+          document: ExtractDocument<TableName, DocumentType>;
           fieldPaths:
             | keyof IdField<TableName>
             | ExtractFieldPaths<DocumentType>;

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -72,7 +72,7 @@ type ExtractDocument<
   TableName extends string,
   T extends Validator<any, any, any>,
 > =
-  // Add the system fields to `Value` and trick TypeScript into expanding them.
+  // Add the `_id` and system fields to `Value` and trick TypeScript into expanding them.
   Expand<IdField<TableName> & SystemFields & T["type"]>;
 
 /**

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -68,7 +68,10 @@ type ExtractFieldPaths<T extends Validator<any, any, any>> =
  *
  * @public
  */
-type ExtractDocument<TableName extends string, T extends Validator<any, any, any>> =
+type ExtractDocument<
+  TableName extends string,
+  T extends Validator<any, any, any>,
+> =
   // Add the system fields to `Value` and trick TypeScript into expanding them.
   Expand<IdField<TableName> & SystemFields & T["type"]>;
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Recent refactors have narrowed the usage of `ExtractDocument`, such that it is now only used in one place (`DataModelFromSchemaDefinition`). This PR specializes its implementation and updates some comments accordingly. (I like the refactors, btw.)

Additionally, I see that both `ExtractFieldPaths` and `ExtractDocument` are marked as `@public` but are not exported. It would be useful for me if they were both exported—any objections to this? If they aren't exported, should the `@public` tags be removed?

It's also not entirely clear to me how open to PRs this repo is, so please let me know if this is unwelcome.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
