### PR TITLE
Fix `.env.local` additions in `.gitignore`

### DIFF
--- a/src/cli/lib/deployment.test.ts
+++ b/src/cli/lib/deployment.test.ts
@@ -71,7 +71,7 @@ test("git ignore changes", () => {
   // Handle whitespace
   expect(changesToGitIgnore(".env.local   ")).toEqual(null);
 
-  // Add .env.local (even if it's negated) to instruct user to solve problem
+  // Add .env.local (even if it's negated) to guide the user to solve the problem
   expect(changesToGitIgnore("!.env.local")).toEqual(
     "!.env.local\n.env.local\n",
   );

--- a/src/cli/lib/deployment.test.ts
+++ b/src/cli/lib/deployment.test.ts
@@ -56,20 +56,23 @@ test("git ignore changes", () => {
   expect(changesToGitIgnore(null)).toEqual(".env.local\n");
   expect(changesToGitIgnore("")).toEqual("\n.env.local\n");
   expect(changesToGitIgnore(".env")).toEqual(".env\n.env.local\n");
+  expect(changesToGitIgnore("# .env.local")).toEqual(
+    "# .env.local\n.env.local\n",
+  );
 
   // Handle existing
   expect(changesToGitIgnore(".env.local")).toEqual(null);
   expect(changesToGitIgnore(".env.*")).toEqual(null);
   expect(changesToGitIgnore(".env*")).toEqual(null);
-
-  // Handle inline comments
-  expect(changesToGitIgnore(".env.local # convex env")).toEqual(null);
+  expect(changesToGitIgnore(".env*.local")).toEqual(null);
+  expect(changesToGitIgnore("*.local")).toEqual(null);
+  expect(changesToGitIgnore("# convex env\n.env.local")).toEqual(null);
 
   // Handle Windows
   expect(changesToGitIgnore(".env.local\r")).toEqual(null);
 
   // Handle whitespace
-  expect(changesToGitIgnore(".env.local   ")).toEqual(null);
+  expect(changesToGitIgnore(" .env.local ")).toEqual(null);
 
   // Add .env.local (even if it's negated) to guide the user to solve the problem
   expect(changesToGitIgnore("!.env.local")).toEqual(

--- a/src/cli/lib/deployment.test.ts
+++ b/src/cli/lib/deployment.test.ts
@@ -52,17 +52,26 @@ test("env var changes", () => {
 });
 
 test("git ignore changes", () => {
+  // Handle additions
   expect(changesToGitIgnore(null)).toEqual(".env.local\n");
-
   expect(changesToGitIgnore("")).toEqual("\n.env.local\n");
-
   expect(changesToGitIgnore(".env")).toEqual(".env\n.env.local\n");
 
+  // Handle existing
   expect(changesToGitIgnore(".env.local")).toEqual(null);
   expect(changesToGitIgnore(".env.*")).toEqual(null);
   expect(changesToGitIgnore(".env*")).toEqual(null);
 
-  // This is wonky, but will guide the user to solve the problem
+  // Handle inline comments
+  expect(changesToGitIgnore(".env.local # convex env")).toEqual(null);
+
+  // Handle Windows
+  expect(changesToGitIgnore(".env.local\r")).toEqual(null);
+
+  // Handle whitespace
+  expect(changesToGitIgnore(".env.local   ")).toEqual(null);
+
+  // Add .env.local (even if it's negated) to instruct user to solve problem
   expect(changesToGitIgnore("!.env.local")).toEqual(
     "!.env.local\n.env.local\n",
   );

--- a/src/cli/lib/deployment.ts
+++ b/src/cli/lib/deployment.ts
@@ -146,14 +146,23 @@ export function changesToGitIgnore(existingFile: string | null): string | null {
     return `${ENV_VAR_FILE_PATH}\n`;
   }
   const gitIgnoreLines = existingFile.split("\n");
-  const envVarFileIgnored = gitIgnoreLines.some(
-    (line) =>
-      line === ".env.local" ||
-      line === ".env.*" ||
-      line === ".env*" ||
-      line === "*.local" ||
-      line === ".env*.local",
-  );
+  const envVarFileIgnored = gitIgnoreLines.some((line) => {
+    // Remove any inline comments
+    const trimmedLine = line.split("#")[0].trim();
+
+    // Ignore negated patterns
+    if (trimmedLine.startsWith("!")) return false;
+
+    const envIgnorePatterns = [
+      /^\.env\.local$/,
+      /^\.env\.\*$/,
+      /^\.env\*$/,
+      /^.*\.local$/,
+      /^\.env\*\.local$/,
+    ];
+
+    return envIgnorePatterns.some((pattern) => pattern.test(trimmedLine));
+  });
   if (!envVarFileIgnored) {
     return `${existingFile}\n${ENV_VAR_FILE_PATH}\n`;
   } else {

--- a/src/cli/lib/deployment.ts
+++ b/src/cli/lib/deployment.ts
@@ -147,18 +147,18 @@ export function changesToGitIgnore(existingFile: string | null): string | null {
   }
   const gitIgnoreLines = existingFile.split("\n");
   const envVarFileIgnored = gitIgnoreLines.some((line) => {
-    // Remove any inline comments
-    const trimmedLine = line.split("#")[0].trim();
+    // Remove extra whitespace
+    const trimmedLine = line.trim();
 
-    // Ignore negated patterns
-    if (trimmedLine.startsWith("!")) return false;
+    // Ignore negated patterns and comments
+    if (trimmedLine.startsWith("!") || trimmedLine.startsWith("#"))
+      return false;
 
     const envIgnorePatterns = [
-      /^\.env\.local$/,
-      /^\.env\.\*$/,
-      /^\.env\*$/,
-      /^.*\.local$/,
-      /^\.env\*\.local$/,
+      // .env.local, .env.*, .env*
+      /^\.env(\.local|\.\*|\*)$/,
+      // .env*.local, *.local
+      /^(\.env)?\*\.local$/,
     ];
 
     return envIgnorePatterns.some((pattern) => pattern.test(trimmedLine));


### PR DESCRIPTION
[Discussed in Discord here.](https://discord.com/channels/1019350475847499849/1320044694138519582/1320044694138519582)

> I'm working on an open source repo that requires contributors to initialize Convex on their local machines. I've noticed a few contributors push code that adds .env.local at the bottom of .gitignore, even though it's already listed above. I think this is being added automatically during the initialization process. Is there a way to disable this, or to improve the .gitignore pattern matching so it doesn't get added?
> 
> ![image](https://github.com/user-attachments/assets/01ba4b12-da84-4be3-8f2b-d8bb33965787)

This PR updates the `changesToGitIgnore()` function to more robustly check for `.env.local` (and related variants), accounting for `/r` on Windows or extra whitespace which previously led to false positives.

New test cases were added to verify the updated conditions.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
