### PR TITLE
only fail awaiting token confirmation for valid auth response

### DIFF
--- a/src/browser/sync/authentication_manager.ts
+++ b/src/browser/sync/authentication_manager.ts
@@ -183,6 +183,17 @@ export class AuthenticationManager {
   }
 
   onAuthError(serverMessage: AuthError) {
+    // If auth error comes from a query/mutation/action and the client
+    // is waiting for the server to confirm a token, ignore.
+    // TODO: This shouldn't rely on a specific error text, make less brittle.
+    // May require backend changes.
+    if (
+      serverMessage.error === "Convex token identity expired" &&
+      (this.authState.state === "waitingForServerConfirmationOfFreshToken" ||
+        this.authState.state === "waitingForServerConfirmationOfCachedToken")
+    ) {
+      return;
+    }
     const { baseVersion } = serverMessage;
     // Versioned AuthErrors are ignored if the client advanced to
     // a newer auth identity


### PR DESCRIPTION
### Bug
An authenticated user is suddenly kicked to the unauthenticated view. This happens often when a native app is brought from background after token has expired, but can happen outside of this context as well.

### Root cause

1. Once token authenticate succeeds, a [refetch is scheduled](https://github.com/get-convex/convex-js/blob/d7bf063017fd93ad5fc28819036af2f50f91874e/src/browser/sync/authentication_manager.ts#L178) for just before the new token expires.
2. The scheduled refetch runs, and auth state is set to [`waitingForServerConfirmationOfFreshToken`](https://github.com/get-convex/convex-js/blob/d7bf063017fd93ad5fc28819036af2f50f91874e/src/browser/sync/authentication_manager.ts#L279-L284).
    - Two things can change this auth state, either a [`Transition` message](https://github.com/get-convex/convex-js/blob/d7bf063017fd93ad5fc28819036af2f50f91874e/src/browser/sync/authentication_manager.ts#L176-L182) showing the server has validated the token, or an [`AuthError`](https://github.com/get-convex/convex-js/blob/d7bf063017fd93ad5fc28819036af2f50f91874e/src/browser/sync/authentication_manager.ts#L196).
    - The server message for a query/mutation with an old token and the message for a failed authentication atttempt both return the same message type of `AuthError` (source links below).
3. In a race condition, around this time, the user initiates a query or mutation with the near-expired token.
4. The server finds the token to be expired and returns an auth error.
5. The query/mutation auth error reaches the client before the Transition message that would otherwise validate the new token.
6. The client [clears authentication state](https://github.com/get-convex/convex-js/blob/d7bf063017fd93ad5fc28819036af2f50f91874e/src/browser/sync/authentication_manager.ts#L210-L226) and the user is shown the unauthenticated view.

Despite the user having a valid session and token, the client remains unauthenticated until refresh/reopen of app.

### This solution

While authentication errors have the same type as expired token responses, the messages are currently distinct.

Error when ModifyQuerySet, Mutation, or Action message encounters an expired token:
https://github.com/get-convex/convex-backend/blob/4121cc0700cf47a16f0861655f1906d810085fba/crates/sync/src/state.rs#L271

Error when an Authenticate message encounters an expired token:
https://github.com/get-convex/convex-backend/blob/4121cc0700cf47a16f0861655f1906d810085fba/crates/authentication/src/lib.rs#L121

This solution is brittle, but fixes the problem until a more permanent fix can be applied. When the auth state is set to `waitingForServerConfirmationOfFreshToken`, only the auth error resulting from an Authenticate request can trigger clearing of auth state in the client. This is done by ignoring query/mutation/action auth errors via message text matching (again, brittle).

### Other solutions considered

An ideal solution would work similarly, but involve more distinct backend handling of these two error states, maybe through an explicit `AuthError` type alternative for Authenticate failures.