### PR TITLE
conditionally restart connection after refetch or reauth

### DIFF
--- a/src/browser/sync/authentication_manager.ts
+++ b/src/browser/sync/authentication_manager.ts
@@ -138,8 +138,6 @@ export class AuthenticationManager {
         hasRetried: false,
       });
       this.authenticate(token.value);
-      this._logVerbose("resuming WS after auth token fetch");
-      this.resumeSocket();
     } else {
       this.setAuthState({
         state: "initialRefetch",
@@ -148,6 +146,8 @@ export class AuthenticationManager {
       // Try again with `forceRefreshToken: true`
       await this.refetchToken();
     }
+    this._logVerbose("resuming WS after auth token fetch");
+    this.resumeSocket();
   }
 
   onTransition(serverMessage: Transition) {
@@ -296,12 +296,7 @@ export class AuthenticationManager {
       }
       this.setAndReportAuthFailed(this.authState.config.onAuthChange);
     }
-    // Resuming in case this refetch was triggered
-    // by an invalid cached token.
-    this._logVerbose(
-      "resuming WS after auth token fetch (if currently paused)",
-    );
-    this.resumeSocket();
+    this.restartSocket();
   }
 
   private scheduleTokenRefetch(token: string) {

--- a/src/browser/sync/web_socket_manager.ts
+++ b/src/browser/sync/web_socket_manager.ts
@@ -431,12 +431,11 @@ export class WebSocketManager {
       case "stopped":
         break;
       case "terminated":
-        // If we're terminating we ignore restart
-        return;
       case "connecting":
       case "ready":
       case "disconnected":
-        throw new Error("`restart()` is only valid after `stop()`");
+        this.logger.warn("Restart called without stopping first");
+        return;
       default: {
         // Enforce that the switch-case is exhaustive.
         const _: never = this.socket;


### PR DESCRIPTION
Fixes #22 

- Move `resumeSocket()` out of `refetchToken()` and into `setConfig()`, which is the only place a pause is initiated. This clarifies where this call actually needs to occur.
- After setting a new token with `refetchToken()` or `tryToReauthenticate()`, if the connection is stopped, restart it. Because it's possible for these two functions to run before or after one another for multiple reasons, this ensures a connection doesn't remain stopped after a potentially successful reauth.
- Change `restartSocket()` to no longer throw if attempted on an unstopped connection, similar to how resume works. Restart is only attempted by `refetchToken()` and `tryToReauthenticate()`, and there's no guarantee whether the connection will be stopped or not.