### PR TITLE
Fix regression in TanStack Start detection

### DIFF
--- a/src/cli/lib/envvars.ts
+++ b/src/cli/lib/envvars.ts
@@ -146,7 +146,7 @@ export async function suggestedEnvVarName(ctx: Context): Promise<{
   }
 
   // TanStackStart currently supports VITE_FOO for browser-side envvars.
-  const isTanStackStart = "@tanstack/start" in packages;
+  const isTanStackStart = "@tanstack/start" in packages || "@tanstack/react-start" in packages;
 
   if (isTanStackStart) {
     return {


### PR DESCRIPTION
The issue with `missing envar CONVEX_URL` has come back in the `start-convex-trellaux` example.

```
? What would you like to configure? choose an existing project
? Project: trellaux-c863f
✔ Reinitialized project trellaux-c863f
✔ Provisioned a dev deployment and saved its:
    name as CONVEX_DEPLOYMENT to .env.local
    URL as CONVEX_URL to .env.local
```

```
♻️  Generating routes...
✅ Processed routes in 69ms

  ➜ Local:    http://localhost:3000/
  ➜ Network:  use --host to expose

missing envar CONVEX_URL
```

Manually copying `CONVEX_URL` as `VITE_CONVEX_URL` solves the error.

I think this regression is caused by the package being renamed: https://github.com/TanStack/router/discussions/2863#discussioncomment-12318045