### PR TITLE
Remove dependency on "react-dom"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - The `npx convex login --login-flow paste` flag can be used to explicitly opt
   into the manual token paste login method.
 
+- Drop support for React 17 and remove use of `unstable_batchedUpdates` as react
+  18 introduced
+  [Automatic batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching)
+
+- Remove dependency on `react-dom`, making it possible to use on "React Native
+  only" projects.
+
 ## 1.23.0
 
 - `npx convex dev` now supports the option of running Convex locally without an

--- a/package.json
+++ b/package.json
@@ -240,14 +240,10 @@
   "peerDependencies": {
     "@auth0/auth0-react": "^2.0.1",
     "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
-    "react": "^17.0.2 || ^18.0.0 || ^19.0.0-0 || ^19.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0-0 || ^19.0.0"
+    "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
-      "optional": true
-    },
-    "react-dom": {
       "optional": true
     },
     "@auth0/auth0-react": {

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -120,7 +120,7 @@ if (process.argv.includes("react-script-tag")) {
       entryPoints: ["src/react/index.ts"],
       bundle: true,
       platform: "browser",
-      external: ["react", "react-dom"],
+      external: ["react"],
       sourcemap: true,
       outfile: tempDir + "/react.bundle.js",
       globalName: "convex",
@@ -128,7 +128,6 @@ if (process.argv.includes("react-script-tag")) {
       plugins: [
         externalGlobalPlugin({
           react: "window.React",
-          "react-dom": "window.ReactDOM",
         }),
       ],
     })

--- a/src/react/client.ts
+++ b/src/react/client.ts
@@ -2,7 +2,6 @@ import { BaseConvexClient } from "../browser/index.js";
 import type { OptimisticUpdate, QueryToken } from "../browser/index.js";
 import React, { useContext, useMemo } from "react";
 import { convexToJson, Value } from "../values/index.js";
-import ReactDOM from "react-dom";
 import { QueryJournal } from "../browser/sync/protocol.js";
 import {
   AuthTokenFetcher,
@@ -26,9 +25,6 @@ import { instantiateDefaultLogger, Logger } from "../browser/logging.js";
 
 if (typeof React === "undefined") {
   throw new Error("Required dependency 'react' not found");
-}
-if (typeof ReactDOM === "undefined") {
-  throw new Error("Required dependency 'react-dom' not found");
 }
 
 // TODO Typedoc doesn't generate documentation for the comment below perhaps
@@ -521,16 +517,14 @@ export class ConvexReactClient {
   }
 
   private transition(updatedQueries: QueryToken[]) {
-    ReactDOM.unstable_batchedUpdates(() => {
-      for (const queryToken of updatedQueries) {
-        const callbacks = this.listeners.get(queryToken);
-        if (callbacks) {
-          for (const callback of callbacks) {
-            callback();
-          }
+    for (const queryToken of updatedQueries) {
+      const callbacks = this.listeners.get(queryToken);
+      if (callbacks) {
+        for (const callback of callbacks) {
+          callback();
         }
       }
-    });
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes https://github.com/get-convex/convex-backend/issues/74

Currently, the react client depends directly on the `react-dom` package, specifically the `unstable_batchedUpdates` implementation. This makes it impossible to use it on `react-native` only projects (with no `react-dom` installed).

`react-native` also implements this method, but it is obsolete since the react 18 release, with the implementation of [Automatic batching](https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching) (explained in more details [here](https://github.com/reactwg/react-18/discussions/21)).

A fix for this could be to test if the client is running react 17 and try o import `unstable_batchedUpdates` from either `react-dom` or `react-native`, but as discussed in the [issue](https://github.com/get-convex/convex-backend/issues/74), a simpler solution could be to drop react 17 support, removing the need to use `unstable_batchedUpdates`.

This PR introduces these changes:
- Remove `react-dom` from the peer dependencies
- Remove version 17 as a valid peer dependency for `react`
- Remove the use the `unstable_batchedUpdates` in the react client `transition` method.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
