### PR TITLE
Fix initial codegen for anonymous projects

### DIFF
--- a/src/cli/configure.ts
+++ b/src/cli/configure.ts
@@ -42,7 +42,11 @@ import {
 import { writeConvexUrlToEnvFile } from "./lib/envvars.js";
 import path from "path";
 import { projectDashboardUrl } from "./lib/dashboard.js";
-import { doCodegen, doInitCodegen } from "./lib/codegen.js";
+import {
+  doCodegen,
+  doCodegenForNewProject,
+  doInitCodegen,
+} from "./lib/codegen.js";
 import { handleLocalDeployment } from "./lib/localDeployment/localDeployment.js";
 import {
   promptOptions,
@@ -598,12 +602,7 @@ async function selectNewProject(
     );
   }
 
-  const { projectConfig: existingProjectConfig } = await readProjectConfig(ctx);
-  const configPath = await configFilepath(ctx);
-  const functionsPath = functionsDir(configPath, existingProjectConfig);
-  await doInitCodegen(ctx, functionsPath, true);
-  // Disable typechecking since there isn't any code yet.
-  await doCodegen(ctx, functionsPath, "disable");
+  await doCodegenForNewProject(ctx);
   return { teamSlug, projectSlug, devDeployment };
 }
 

--- a/src/cli/lib/codegen.ts
+++ b/src/cli/lib/codegen.ts
@@ -20,7 +20,7 @@ import {
   logVerbose,
 } from "../../bundler/context.js";
 import { typeCheckFunctionsInMode, TypeCheckMode } from "./typecheck.js";
-import { readProjectConfig } from "./config.js";
+import { configFilepath, readProjectConfig } from "./config.js";
 import { recursivelyDelete } from "./fsUtils.js";
 import {
   componentServerDTS,
@@ -35,6 +35,7 @@ import {
   componentApiStubDTS,
   rootComponentApiCJS,
 } from "../codegen_templates/component_api.js";
+import { functionsDir } from "./utils/utils.js";
 
 export type CodegenOptions = {
   url?: string;
@@ -46,6 +47,15 @@ export type CodegenOptions = {
   commonjs: boolean;
   liveComponentSources: boolean;
 };
+
+export async function doCodegenForNewProject(ctx: Context) {
+  const { projectConfig: existingProjectConfig } = await readProjectConfig(ctx);
+  const configPath = await configFilepath(ctx);
+  const functionsPath = functionsDir(configPath, existingProjectConfig);
+  await doInitCodegen(ctx, functionsPath, true);
+  // Disable typechecking since there isn't any code yet.
+  await doCodegen(ctx, functionsPath, "disable");
+}
 
 export async function doInitCodegen(
   ctx: Context,

--- a/src/cli/lib/localDeployment/anonymous.ts
+++ b/src/cli/lib/localDeployment/anonymous.ts
@@ -43,6 +43,8 @@ import { isAnonymousDeployment } from "../deployment.js";
 import { createProject } from "../api.js";
 import { removeAnonymousPrefix } from "../deployment.js";
 import { nodeFs } from "../../../bundler/fs.js";
+import { doCodegenForNewProject, doInitCodegen } from "../codegen.js";
+import { functionsDir } from "../utils/utils.js";
 
 export async function handleAnonymousDeployment(
   ctx: Context,
@@ -174,6 +176,9 @@ export async function handleAnonymousDeployment(
     }
   });
 
+  if (deployment.kind === "new") {
+    await doCodegenForNewProject(ctx);
+  }
   return {
     adminKey,
     deploymentName: deployment.deploymentName,


### PR DESCRIPTION
This fixes a bug in the new no-login (anonymous) flow, where there's no initial codegen, so tsconfig.json (and README) were missing.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
