### PR TITLE
Nits in generated README

### DIFF
--- a/src/cli/codegen_templates/readme.ts
+++ b/src/cli/codegen_templates/readme.ts
@@ -7,7 +7,7 @@ See https://docs.convex.dev/functions for more.
 A query function that takes two arguments looks like:
 
 \`\`\`ts
-// functions.js
+// convex/myFunctions.ts
 import { query } from "./_generated/server";
 import { v } from "convex/values";
 
@@ -44,7 +44,7 @@ const data = useQuery(api.functions.myQueryFunction, { first: 10, second: "hello
 A mutation function looks like:
 
 \`\`\`ts
-// functions.js
+// convex/myFunctions.ts
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 


### PR DESCRIPTION
Convex is TS-first for quite a while, but these paths slipped through.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
