### PR TITLE
attempt close and reconnect for all stopped/disconnected states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 temp/
 dist
 node_modules
+.vscode
 
 # The convex npm package does not use a package-lock.json.
 package-lock.json


### PR DESCRIPTION
Code execution in inactive browser tabs is sporadic and unreliable. The remaining race conditions I've observed in long running tabs have to do with delayed settimeouts and scheduled reconnects clobbering each other, resulting in unexpected websocket state transitions, and ultimately false unauth states.

This change allows stopped and disconnected states, which can happen unexpectedly and lead to a false unauth state, to at least attempt reconnect.

I've been running this for weeks and saw no remaining race conditions and no logouts, but made some slight changes for this PR, so opening as draft for now.