### PR TITLE
Add ConvexProviderWithAuthKit for WorkOS AuthKit integration

### DIFF
--- a/api-extractor-configs/react-authkit-api-extractor.json
+++ b/api-extractor-configs/react-authkit-api-extractor.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./api-extractor-base.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/types/react-authkit/index.d.ts",
+  "dtsRollup": {
+    "untrimmedFilePath": "<projectFolder>/dist/types/react-authkit/react-authkit-internal.d.ts",
+    "publicTrimmedFilePath": "<projectFolder>/dist/types/react-authkit/react-authkit.d.ts"
+  },
+  /**
+   * Enable the apiReport but use the same reportFolder and tempFolder to make it a no-op.
+   * This way forgotten exports are a warning instead of an error.
+   */
+  "apiReport": {
+    "enabled": true,
+    "reportFileName": "react-authkit-tmp.api.md",
+    "reportFolder": "temp",
+    "reportTempFolder": "temp"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -285,6 +285,7 @@
     "@types/serve-handler": "~6.1.4",
     "@types/ws": "^8.5.13",
     "@vitest/eslint-plugin": "~1.3.0",
+    "@workos-inc/authkit-react": "^0.11.0",
     "adm-zip": "^0.5.10",
     "bufferutil": "^4.0.7",
     "chalk": "5",

--- a/react-authkit/package.json
+++ b/react-authkit/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/cjs/react-authkit/index.js",
+  "module": "../dist/esm/react-authkit/index.js",
+  "types": "../dist/cjs-types/react-authkit/index.d.ts"
+}

--- a/src/react-authkit/ConvexProviderWithAuthKit.test.tsx
+++ b/src/react-authkit/ConvexProviderWithAuthKit.test.tsx
@@ -1,0 +1,18 @@
+/**
+ * @vitest-environment custom-vitest-environment.ts
+ */
+import { test } from "vitest";
+import React from "react";
+import { ConvexProviderWithAuthKit } from "./ConvexProviderWithAuthKit.js";
+import { ConvexReactClient } from "../react/index.js";
+import { useAuth } from "@workos-inc/authkit-react";
+
+test("Helpers are valid children", () => {
+  const convex = new ConvexReactClient("https://localhost:3001");
+
+  const _ = (
+    <ConvexProviderWithAuthKit client={convex} useAuth={useAuth}>
+      Hello world
+    </ConvexProviderWithAuthKit>
+  );
+});

--- a/src/react-authkit/ConvexProviderWithAuthKit.tsx
+++ b/src/react-authkit/ConvexProviderWithAuthKit.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+import { ReactNode, useCallback, useMemo } from "react";
+import { AuthTokenFetcher } from "../browser/sync/client.js";
+import { ConvexProviderWithAuth } from "../react/ConvexAuthState.js";
+
+type IConvexReactClient = {
+  setAuth(fetchToken: AuthTokenFetcher): void;
+  clearAuth(): void;
+};
+
+// Modified to match WorkOS's auth hook structure
+type UseAuth = () => {
+  isLoading: boolean;
+  user: any | null;
+  getAccessToken: () => Promise<string | null>;
+};
+
+/**
+ * A wrapper React component which provides a {@link react.ConvexReactClient}
+ * authenticated with WorkOS AuthKit.
+ *
+ * It must be wrapped by a configured `AuthKitProvider`, from
+ * `@workos-inc/authkit-react`.
+ *
+ * @public
+ */
+export function ConvexProviderWithAuthKit({
+  children,
+  client,
+  useAuth,
+}: {
+  children: ReactNode;
+  client: IConvexReactClient;
+  useAuth: UseAuth;
+}) {
+  const useAuthFromWorkOS = useUseAuthFromWorkOS(useAuth);
+  return (
+    <ConvexProviderWithAuth client={client} useAuth={useAuthFromWorkOS}>
+      {children}
+    </ConvexProviderWithAuth>
+  );
+}
+
+function useUseAuthFromWorkOS(useAuth: UseAuth) {
+  return useMemo(
+    () =>
+      function useAuthFromWorkOS() {
+        const { isLoading, user, getAccessToken } = useAuth();
+        getAccessToken().then((token) => console.log({ user, token }));
+
+        const fetchAccessToken = useCallback(async () => {
+          try {
+            const token = await getAccessToken();
+            return token;
+          } catch (error) {
+            return null;
+          }
+        }, [getAccessToken]);
+
+        return useMemo(
+          () => ({
+            isLoading,
+            isAuthenticated: !!user,
+            fetchAccessToken,
+          }),
+          [isLoading, user, fetchAccessToken],
+        );
+      },
+    [useAuth],
+  );
+}

--- a/src/react-authkit/index.ts
+++ b/src/react-authkit/index.ts
@@ -1,0 +1,6 @@
+/**
+ * React login component for use with WorkOS AuthKit
+ *
+ * @module
+ */
+export { ConvexProviderWithAuthKit } from "./ConvexProviderWithAuthKit.js";


### PR DESCRIPTION
## Summary
- Add ConvexProviderWithAuthKit component for integrating Convex with WorkOS AuthKit
- Create new react-authkit package with proper build configuration
- Add @workos-inc/authkit-react as a dev dependency for testing

## Changes
- **src/react-authkit/ConvexProviderWithAuthKit.tsx**: New provider component that wraps ConvexProviderWithAuth and adapts WorkOS's auth hook structure
- **src/react-authkit/index.ts**: Export the new component
- **react-authkit/package.json**: Package configuration for the new module
- **api-extractor-configs/react-authkit-api-extractor.json**: API extractor configuration for type definitions
- **package.json**: Added @workos-inc/authkit-react dev dependency


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
