### PR TITLE
types(OptionalRestArgs): truly only require `args` input when necessary

### DIFF
--- a/src/react/client.ts
+++ b/src/react/client.ts
@@ -21,7 +21,7 @@ import {
   getFunctionName,
   makeFunctionReference,
 } from "../server/api.js";
-import { EmptyObject } from "../server/registration.js";
+import { AreAllPropertiesOptional } from "../server/registration.js";
 import {
   instantiateDefaultLogger,
   instantiateNoopLogger,
@@ -606,9 +606,9 @@ export const ConvexProvider: React.FC<{
 };
 
 export type OptionalRestArgsOrSkip<FuncRef extends FunctionReference<any>> =
-  FuncRef["_args"] extends EmptyObject
-    ? [args?: EmptyObject | "skip"]
-    : [args: FuncRef["_args"] | "skip"];
+  AreAllPropertiesOptional<FuncRef['_args']> extends true
+    ? [args?: FuncRef['_args'] | "skip"]
+    : [args: FuncRef['_args'] | "skip"];
 
 /**
  * Load a reactive query within a React component.

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -5,6 +5,7 @@ import {
   RegisteredAction,
   RegisteredMutation,
   RegisteredQuery,
+  AreAllPropertiesOptional,
 } from "./registration.js";
 import { Expand, UnionToIntersection } from "../type_utils.js";
 import { PaginationOptions, PaginationResult } from "./pagination.js";
@@ -444,9 +445,9 @@ export type FunctionArgs<FuncRef extends AnyFunctionReference> =
  * @public
  */
 export type OptionalRestArgs<FuncRef extends AnyFunctionReference> =
-  FuncRef["_args"] extends EmptyObject
-    ? [args?: EmptyObject]
-    : [args: FuncRef["_args"]];
+  AreAllPropertiesOptional<FuncRef['_args']> extends true
+    ? [args?: FuncRef['_args']]
+    : [args: FuncRef['_args']]
 
 /**
  * A tuple type of the (maybe optional) arguments to `FuncRef`, followed by an options
@@ -460,9 +461,10 @@ export type OptionalRestArgs<FuncRef extends AnyFunctionReference> =
 export type ArgsAndOptions<
   FuncRef extends AnyFunctionReference,
   Options,
-> = FuncRef["_args"] extends EmptyObject
-  ? [args?: EmptyObject, options?: Options]
-  : [args: FuncRef["_args"], options?: Options];
+> = 
+  AreAllPropertiesOptional<FuncRef['_args']> extends true
+    ? [args?: FuncRef['_args'], options?: Options]
+    : [args: FuncRef['_args'], options?: Options]
 
 /**
  * Given a {@link FunctionReference}, get the return type of the function.

--- a/src/server/registration.ts
+++ b/src/server/registration.ts
@@ -308,6 +308,22 @@ export type ArgsArray = OneArgArray | NoArgsArray;
 export type EmptyObject = Record<string, never>;
 
 /**
+ * Is a property key of a type optional
+ */
+export type IsOptionalKey<T, K extends keyof T> =
+  object extends Pick<T, K> ? true : false
+
+/**
+ * Are all properties of a type optional
+ */
+export type AreAllPropertiesOptional<T> =
+  true extends {
+    [K in keyof T]: IsOptionalKey<T, K> extends true ? never : true
+  }[keyof T]
+    ? false
+    : true
+
+/**
  * Convert an {@link ArgsArray} into a single object type.
  *
  * Empty arguments arrays are converted to {@link EmptyObject}.


### PR DESCRIPTION
<!-- Describe your PR here. -->

Currently `args` are still required even though all of it's properties are optional, this change adds `IsOptionalKey` and `AreAllPropertiesOptional` util types, and use it to achieve "truly necessary requirement only" of `args`.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
