### PR TITLE
Fix auth not being set when passed as parameter in ConvexHttpClient

### DIFF
--- a/src/browser/http_client.ts
+++ b/src/browser/http_client.ts
@@ -117,6 +117,7 @@ export class ConvexHttpClient {
           : instantiateDefaultLogger({ verbose: false });
     this.address = address;
     this.debug = true;
+    this.auth = options?.auth;
   }
 
   /**


### PR DESCRIPTION
Got bit today by this. I passed the token obtained from `useAuthToken`, but the class was not setting the auth token.

https://github.com/get-convex/convex-js/blob/817ee167f95f0cdb83943cba3ed5fce9942bd7b4/src/browser/http_client.ts#L77-L120