### PR TITLE
Allow CONVEX_CONFIG_PATH to be a environment variable

### DIFF
--- a/src/cli/lib/utils/globalConfig.ts
+++ b/src/cli/lib/utils/globalConfig.ts
@@ -1,13 +1,13 @@
 import chalk from "chalk";
 import os from "os";
-import path from "path";
 import { rootDirectory } from "./utils.js";
 import { Context } from "../../../bundler/context.js";
 import { logError, logVerbose } from "../../../bundler/log.js";
 import { z } from "zod";
+import { CONVEX_CONFIG_PATH } from "./utils.js";
 
 export function globalConfigPath(): string {
-  return path.join(rootDirectory(), "config.json");
+  return CONVEX_CONFIG_PATH;
 }
 
 // GlobalConfig is stored in a file that very old versions of Convex also need to access.

--- a/src/cli/lib/utils/utils.ts
+++ b/src/cli/lib/utils/utils.ts
@@ -34,6 +34,7 @@ export const CONVEX_DEPLOYMENT_ENV_VAR_NAME = "CONVEX_DEPLOYMENT";
 export const CONVEX_SELF_HOSTED_URL_VAR_NAME = "CONVEX_SELF_HOSTED_URL";
 export const CONVEX_SELF_HOSTED_ADMIN_KEY_VAR_NAME =
   "CONVEX_SELF_HOSTED_ADMIN_KEY";
+export const CONVEX_CONFIG_PATH = path.join(rootDirectory(), "config.json");
 const MAX_RETRIES = 6;
 // After 3 retries, log a progress message that we're retrying the request
 const RETRY_LOG_THRESHOLD = 3;

--- a/src/cli/lib/utils/utils.ts
+++ b/src/cli/lib/utils/utils.ts
@@ -24,6 +24,10 @@ import {
 
 const retryingFetch = fetchRetryFactory(fetch);
 
+export function rootDirectory(): string {
+  return path.join(os.homedir(), `.${convexName()}`);
+}
+
 export const productionProvisionHost = "https://api.convex.dev";
 export const provisionHost =
   process.env.CONVEX_PROVISION_HOST || productionProvisionHost;
@@ -551,10 +555,6 @@ function convexName() {
     }
   }
   return "convex";
-}
-
-export function rootDirectory(): string {
-  return path.join(os.homedir(), `.${convexName()}`);
 }
 
 export function cacheDir() {


### PR DESCRIPTION
The behavior of CONVEX_DEPLOY_KEY changes depending on if the current user is logged into convex via the CLI. This has some unintended consequences for users with a large number of projects.

<!-- Describe your PR here. -->

The current behavior is correct for about 99% of Convex developers, however, in some cases (those with a very large number of projects) it limits their ability to deploy. The temp solution is to remove or rename the $HOME/.convex/config.json in order to allow deployment to a project that the user isn't a member of.

By allow this to be an environment variable it allows a user, at deploy time, to determine with auth details (or lack thereof) are used.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
