### PR TITLE
Detect empty env vars

### DIFF
--- a/src/cli/lib/deploymentSelection.ts
+++ b/src/cli/lib/deploymentSelection.ts
@@ -347,7 +347,7 @@ async function _getDeploymentSelection(
     };
   }
 
-  if (cliArgs.envFile === undefined) {
+  if (cliArgs.envFile !== undefined) {
     // If an `--env-file` is specified, it must contain enough information for both auth and deployment selection.
     logVerbose(`Checking env file: ${cliArgs.envFile}`);
     const existingFile = ctx.fs.exists(cliArgs.envFile)


### PR DESCRIPTION
I just burned half an hour thanks to this. Boolean coercion is evil. I was setting these options in CI, and due to a misconfiguration one of them was empty string. What was worse, I couldn't repro this locally, because if you have `.env.local` with `CONVEX_DEPLOYMENT`, and even if you're not logged in, `npx convex deploy --url "" --admin-key ""` does the right thing, but if you don't have `.env.local`, then you get erronously:

```
$ npx convex deploy --admin-key "" --url ""
You are currently developing anonymously with a locally running project. To deploy your Convex app to the cloud, log in by running `npx convex login`. See https://docs.convex.dev/production for more information on how Convex cloud works and instructions on how to set up hosting.
```

I'd turn on a lint rule that disallows boolean coercion altogether (I don't remember why we didn't do it in the past, maybe it didn't exist?).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
