### PR TITLE
fix: sp valiators -> validators

### DIFF
--- a/src/values/validators.ts
+++ b/src/values/validators.ts
@@ -299,7 +299,7 @@ export class VObject<
     super({ isOptional });
     globalThis.Object.values(fields).forEach((v) => {
       if (!v.isConvexValidator) {
-        throw new Error("v.object() entries must be valiators");
+        throw new Error("v.object() entries must be validators");
       }
     });
     this.fields = fields;


### PR DESCRIPTION
Just a quick spelling fix in the error message: valiators -> validators



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
