### PR TITLE
feat(nextjs): add abortsignal support for react 19.2 cachesignal

### DIFF
--- a/src/browser/http_client.ts
+++ b/src/browser/http_client.ts
@@ -576,4 +576,7 @@ function forwardErrorData(errorData: JSONValue, error: ConvexError<string>) {
 /**
  * @internal
  */
-type FetchOptions = { cache: "force-cache" | "no-store" };
+type FetchOptions = {
+  cache: "force-cache" | "no-store";
+  signal?: AbortSignal;
+};

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -84,6 +84,12 @@ export type NextjsOptions = {
    * The default value is `false`
    */
   skipConvexDeploymentUrlCheck?: boolean;
+  /**
+   * AbortSignal to cancel the request.
+   *
+   * Use with React 19.2's cacheSignal() to abort fetches when cache lifetime ends.
+   */
+  signal?: AbortSignal | null;
 };
 
 /**
@@ -199,7 +205,10 @@ function setupClient(options: NextjsOptions) {
   if (options.adminToken !== undefined) {
     client.setAdminAuth(options.adminToken);
   }
-  client.setFetchOptions({ cache: "no-store" });
+  client.setFetchOptions({
+    cache: "no-store",
+    signal: options.signal ?? undefined,
+  });
   return client;
 }
 


### PR DESCRIPTION
## Summary

Adds `signal` parameter to `NextjsOptions` to support React 19.2's `cacheSignal()` API for automatic request cancellation.

## Motivation

React 19.2 introduced `cacheSignal()` which returns an `AbortSignal` that automatically aborts when:
- Render completes successfully
- Render is aborted
- User navigates away
- Cache lifetime ends

This prevents wasted network requests and enables proper cleanup in Server Components.

## Changes

**Type Definitions:**
- Added `signal?: AbortSignal | null` to `NextjsOptions` in `src/nextjs/index.ts`
- Added `signal?: AbortSignal` to `FetchOptions` in `src/browser/http_client.ts`

**Runtime:**
- Pass `signal` from options to `client.setFetchOptions()` in `setupClient()`
- Signal flows through to all `fetch()` calls automatically

## Example Usage

```typescript
import { cacheSignal } from 'react';
import { fetchQuery } from 'convex/nextjs';
import { api } from '@/convex/_generated/api';

export async function getProducts() {
  'use cache';
  
  return await fetchQuery(
    api.catalog.getProducts,
    {},
    { signal: cacheSignal() }
  );
}
```

## Testing

- TypeScript compilation passes
- Build succeeds with signal parameter
- Backwards compatible (signal is optional)
- Works with all function types (query/mutation/action)
- Tested in production Next.js 16 + React 19.2 application

## References

- [React 19.2 cacheSignal docs](https://react.dev/reference/react/cacheSignal)