### PR TITLE
bug: fix client query loading and auth behavior in usePreloadedQuery

### DIFF
--- a/src/react/hydration.tsx
+++ b/src/react/hydration.tsx
@@ -34,8 +34,16 @@ export type Preloaded<Query extends FunctionReference<"query">> = {
  * @public
  */
 export function usePreloadedQuery<Query extends FunctionReference<"query">>(
+  preloadedQuery: Preloaded<Query>,
+): Query["_returnType"];
+
+export function usePreloadedQuery<Query extends FunctionReference<"query">>(
   preloadedQuery: Preloaded<Query> | "skip",
-): Query["_returnType"] | undefined {
+): Query["_returnType"] | undefined;
+
+export function usePreloadedQuery<Query extends FunctionReference<"query">>(
+  preloadedQuery: Preloaded<Query> | "skip",
+) {
   const skip = preloadedQuery === "skip";
 
   const args = useMemo(

--- a/src/react/hydration.tsx
+++ b/src/react/hydration.tsx
@@ -25,11 +25,11 @@ export type Preloaded<Query extends FunctionReference<"query">> = {
  *
  * Throws an error if not used under {@link ConvexProvider}.
  *
- * @param preloadedQuery - The `Preloaded` query payload from a Server Component.
- * @param options - Options for the query, including whether to skip it.
+ * @param preloadedQuery - The `Preloaded` query payload from a Server Component,
+ * or the string `"skip"` to skip the query.
  * @returns the result of the query. Initially returns the result fetched
  * by the Server Component. Subsequently returns the result fetched by the client.
- * If the query is skipped, returns `undefined`.
+ * If the query is skipped (by passing `"skip"`), returns `undefined`.
  *
  * @public
  */


### PR DESCRIPTION
<!-- Describe your PR here. -->

As discussed in this [discord thread](https://discord.com/channels/1019350475847499849/1430407429505679462), I've created a [minimal demo repo](https://github.com/chenxin-yan/convex-preloadedquery-example) to showcase the DX and UX differences between with/without skip option for `usePreloadedQuery`

The primary motivation for this is it would be nice to have an elegant and intuitive api for waiting for auth token to be loaded on client without blocking other parts of the component. With current api, to achieve this you can create another client component and wrap it with `<Authenticated/>`, but it becomes tedious in a lot of cases where you do not want to decouple the rendering logic to another component.

before:
```tsx
import { preloadQuery } from "convex/nextjs";
import { getAuthToken } from "@/lib/convex";
import { api } from "../../../convex/_generated/api";
import { AuthenticatedContent } from "./components/AuthenticatedContent";
import { TodoList } from "./components/TodoList";

const OldPage = async () => {
  const token = await getAuthToken();
  const preloadedTodos = await preloadQuery(api.tasks.get, {}, { token });

  return (
    <AuthenticatedContent>
      <TodoList preloadedTodos={preloadedTodos} />
    </AuthenticatedContent>
  );
};

export default OldPage;
```
```tsx
"use client";

import { type Preloaded, usePreloadedQuery } from "convex/react";
import type { api } from "../../../../convex/_generated/api";

interface Props {
  preloadedTodos: Preloaded<typeof api.tasks.get>;
}

export function TodoList({ preloadedTodos }: Props) {
  const todos = usePreloadedQuery(preloadedTodos);

  return (
    <>
      <h1>some todos:</h1>
      <ul>
        {todos.map((todo) => (
          <li key={todo._id}>{todo.text}</li>
        ))}
      </ul>
      <p>above are my todos</p>
    </>
  );
}
```

![2025-10-23 23 22 43](https://github.com/user-attachments/assets/cba56c05-7a2c-450f-b5ab-514da0f242eb)

After:

```tsx
import { getAuthToken } from "@/lib/convex";
import { preloadQuery } from "convex/nextjs";
import { api } from "../../../convex/_generated/api";
import { TodoList } from "./components/TodoList";

const NewPage = async () => {
  const token = await getAuthToken();
  const preloadedTodos = await preloadQuery(api.tasks.get, {}, { token });

  return <TodoList preloadedTodos={preloadedTodos} />;
};

export default NewPage;
```

```tsx
"use client";

import { type Preloaded, useConvexAuth, usePreloadedQuery } from "convex/react";
import type { api } from "../../../../convex/_generated/api";

interface Props {
  preloadedTodos: Preloaded<typeof api.tasks.get>;
}

export function TodoList({ preloadedTodos }: Props) {
  const { isLoading } = useConvexAuth();
  const todos = usePreloadedQuery(preloadedTodos, { skip: isLoading });

  return (
    <>
      <h1>some todos:</h1>
      <ul>
        {todos ? (
          todos.map((todo) => <li key={todo._id}>{todo.text}</li>)
        ) : (
          <p>loading...</p>
        )}
      </ul>
      <p>above are my todos</p>
    </>
  );
}

```
![2025-10-23 23 23 28](https://github.com/user-attachments/assets/c73a03ed-91b2-46db-90f5-e133ad7d13d8)


Closes #98 

I am not sure if I missed anything from documentation that can handle this more elegantly, but it is weird to me that you can skip `useQuery` but not `usePreloadedQuery`.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
