### PR TITLE
ferntheplant - include the requestId in the context for actions

### DIFF
--- a/src/server/impl/registration_impl.ts
+++ b/src/server/impl/registration_impl.ts
@@ -355,6 +355,7 @@ async function invokeAction<
   const calls = setupActionCalls(requestId);
   const ctx = {
     ...calls,
+    requestId,
     auth: setupAuth(requestId),
     scheduler: setupActionScheduler(requestId),
     storage: setupStorageActionWriter(requestId),
@@ -445,6 +446,7 @@ async function invokeHttpAction<
   const calls = setupActionCalls(requestId);
   const ctx = {
     ...calls,
+    requestId,
     auth: setupAuth(requestId),
     storage: setupStorageActionWriter(requestId),
     scheduler: setupActionScheduler(requestId),

--- a/src/server/registration.ts
+++ b/src/server/registration.ts
@@ -231,6 +231,11 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
   ): Promise<FunctionReturnType<Action>>;
 
   /**
+   * The request ID for the current function call.
+   */
+  requestId: string;
+
+  /**
    * A utility for scheduling Convex functions to run in the future.
    */
   scheduler: Scheduler;


### PR DESCRIPTION
<!-- Describe your PR here. -->

Include the `requestId` from the backend in the action ctx. This allows users to forward the `requestId` to external services for unified cross-service tracing


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
