### PR TITLE
Add component support to MCP tools

### DIFF
--- a/src/cli/lib/mcp/tools/componentResolver.ts
+++ b/src/cli/lib/mcp/tools/componentResolver.ts
@@ -1,0 +1,54 @@
+import { Context } from "../../../../bundler/context.js";
+import { runSystemQuery } from "../../run.js";
+
+export type ComponentInfo = {
+  id: string;
+  name: string | null;
+  path: string;
+  state: string;
+};
+
+/**
+ * Resolves a component path or ID to a full ComponentInfo object.
+ * Accepts either:
+ * - A component path (e.g., "widget", "parent/child")
+ * - A component ID (e.g., "kh72fgh3j4...")
+ *
+ * Returns the matched component and the full list of available components.
+ */
+export async function resolveComponent(
+  ctx: Context,
+  credentials: { url: string; adminKey: string },
+  componentPathOrId: string | undefined,
+): Promise<{ component: ComponentInfo | null; allComponents: ComponentInfo[] }> {
+  // Fetch all components from the deployment
+  const allComponents = (await runSystemQuery(ctx, {
+    deploymentUrl: credentials.url,
+    adminKey: credentials.adminKey,
+    functionName: "_system/frontend/components:list",
+    componentPath: undefined,
+    args: {},
+  })) as ComponentInfo[];
+
+  if (!componentPathOrId) {
+    return { component: null, allComponents };
+  }
+
+  // Try to match by path first (more common), then by ID
+  const component =
+    allComponents.find((c) => c.path === componentPathOrId) ||
+    allComponents.find((c) => c.id === componentPathOrId);
+
+  return { component: component || null, allComponents };
+}
+
+/**
+ * Formats a helpful error message when a component is not found.
+ */
+export function formatComponentError(
+  componentPathOrId: string,
+  allComponents: ComponentInfo[],
+): string {
+  const available = allComponents.map((c) => c.path || "(root)").join(", ");
+  return `Component '${componentPathOrId}' not found. Available components: ${available}`;
+}

--- a/src/cli/lib/mcp/tools/components.ts
+++ b/src/cli/lib/mcp/tools/components.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { ConvexTool } from "./index.js";
+import { loadSelectedDeploymentCredentials } from "../../api.js";
+import { getDeploymentSelection } from "../../deploymentSelection.js";
+import { resolveComponent } from "./componentResolver.js";
+
+const inputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe(
+      "Deployment selector (from the status tool) to list components from.",
+    ),
+});
+
+const outputSchema = z.object({
+  components: z.array(
+    z.object({
+      id: z.string().describe("Component ID (can be used as componentPath)"),
+      name: z
+        .string()
+        .nullable()
+        .describe("Component name (null for root)"),
+      path: z
+        .string()
+        .describe(
+          "Component path (e.g., 'widget') - use this with other tools",
+        ),
+      state: z
+        .string()
+        .describe("Component state ('active' or 'unmounted')"),
+    }),
+  ),
+});
+
+const description = `
+List all components in a Convex deployment.
+
+Use the returned 'path' values as the componentPath parameter in other tools
+(tables, data, functionSpec, run). You can also use the 'id' if needed.
+
+The root component has an empty path ("").
+`.trim();
+
+export const ComponentsTool: ConvexTool<typeof inputSchema, typeof outputSchema> =
+  {
+    name: "components",
+    description,
+    inputSchema,
+    outputSchema,
+    handler: async (ctx, args) => {
+      const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
+        args.deploymentSelector,
+      );
+      process.chdir(projectDir);
+      const deploymentSelection = await getDeploymentSelection(
+        ctx,
+        ctx.options,
+      );
+      const credentials = await loadSelectedDeploymentCredentials(
+        ctx,
+        deploymentSelection,
+        deployment,
+      );
+
+      const { allComponents } = await resolveComponent(
+        ctx,
+        credentials,
+        undefined,
+      );
+      return { components: allComponents };
+    },
+  };

--- a/src/cli/lib/mcp/tools/data.ts
+++ b/src/cli/lib/mcp/tools/data.ts
@@ -17,6 +17,12 @@ const inputSchema = z.object({
     .max(1000)
     .optional()
     .describe("The maximum number of results to return, defaults to 100."),
+  componentPath: z
+    .string()
+    .optional()
+    .describe(
+      "Component path (e.g., 'widget') or component ID. Use the 'components' tool to list available components. Omit for root.",
+    ),
 });
 
 const outputSchema = z.object({
@@ -54,7 +60,7 @@ export const DataTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
       deploymentUrl: credentials.url,
       adminKey: credentials.adminKey,
       functionName: "_system/cli/tableData",
-      componentPath: undefined,
+      componentPath: args.componentPath,
       args: {
         table: args.tableName,
         order: args.order,

--- a/src/cli/lib/mcp/tools/functionSpec.ts
+++ b/src/cli/lib/mcp/tools/functionSpec.ts
@@ -10,6 +10,12 @@ const inputSchema = z.object({
     .describe(
       "Deployment selector (from the status tool) to get function metadata from.",
     ),
+  componentPath: z
+    .string()
+    .optional()
+    .describe(
+      "Component path (e.g., 'widget') or component ID. Use the 'components' tool to list available components. Omit for root.",
+    ),
 });
 
 const outputSchema = z
@@ -49,7 +55,7 @@ export const FunctionSpecTool: ConvexTool<
       deploymentUrl: credentials.url,
       adminKey: credentials.adminKey,
       functionName: "_system/cli/modules:apiSpec",
-      componentPath: undefined,
+      componentPath: args.componentPath,
       args: {},
     });
     return functions;

--- a/src/cli/lib/mcp/tools/index.ts
+++ b/src/cli/lib/mcp/tools/index.ts
@@ -9,6 +9,7 @@ import { RunTool } from "./run.js";
 import { EnvListTool, EnvGetTool, EnvSetTool, EnvRemoveTool } from "./env.js";
 import { RunOneoffQueryTool } from "./runOneoffQuery.js";
 import { LogsTool } from "./logs.js";
+import { ComponentsTool } from "./components.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 export type ConvexTool<Input extends ZodTypeAny, Output extends ZodTypeAny> = {
@@ -34,6 +35,7 @@ export function mcpTool(tool: ConvexTool<ZodTypeAny, ZodTypeAny>): Tool {
 
 export const convexTools: ConvexTool<any, any>[] = [
   StatusTool,
+  ComponentsTool,
   DataTool,
   TablesTool,
   FunctionSpecTool,

--- a/src/cli/lib/mcp/tools/run.ts
+++ b/src/cli/lib/mcp/tools/run.ts
@@ -23,6 +23,12 @@ const inputSchema = z.object({
     .describe(
       "The argument object to pass to the function, JSON-encoded as a string.",
     ),
+  componentPath: z
+    .string()
+    .optional()
+    .describe(
+      "Component path (e.g., 'widget') or component ID. Use the 'components' tool to list available components. Omit for root.",
+    ),
 });
 
 const outputSchema = z.object({
@@ -72,7 +78,11 @@ export const RunTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
     client.setAdminAuth(credentials.adminKey);
     let result: Value;
     try {
-      result = await client.function(parsedFunctionName, undefined, parsedArgs);
+      result = await client.function(
+        parsedFunctionName,
+        args.componentPath,
+        parsedArgs,
+      );
     } catch (err) {
       return await ctx.crash({
         exitCode: 1,

--- a/src/cli/lib/mcp/tools/tables.ts
+++ b/src/cli/lib/mcp/tools/tables.ts
@@ -4,12 +4,19 @@ import { loadSelectedDeploymentCredentials } from "../../api.js";
 import { runSystemQuery } from "../../run.js";
 import { deploymentFetch } from "../../utils/utils.js";
 import { getDeploymentSelection } from "../../deploymentSelection.js";
+import { resolveComponent, formatComponentError } from "./componentResolver.js";
 
 const inputSchema = z.object({
   deploymentSelector: z
     .string()
     .describe(
       "Deployment selector (from the status tool) to read tables from.",
+    ),
+  componentPath: z
+    .string()
+    .optional()
+    .describe(
+      "Component path (e.g., 'widget') or component ID. Use the 'components' tool to list available components. Omit for root.",
     ),
 });
 
@@ -26,7 +33,7 @@ const outputSchema = z.object({
 export const TablesTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
   name: "tables",
   description:
-    "List all tables in a particular Convex deployment and their inferred and declared schema.",
+    "List all tables in a Convex deployment (or component) and their inferred and declared schema. Use componentPath to view a component's tables.",
   inputSchema,
   outputSchema,
   handler: async (ctx, args) => {
@@ -40,11 +47,29 @@ export const TablesTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
       deploymentSelection,
       deployment,
     );
+
+    // Resolve componentPath to get both path and ID
+    const { component, allComponents } = await resolveComponent(
+      ctx,
+      credentials,
+      args.componentPath,
+    );
+
+    // If componentPath was provided but not found, return helpful error
+    if (args.componentPath && !component) {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "fatal",
+        printedMessage: formatComponentError(args.componentPath, allComponents),
+      });
+    }
+
+    // Use path for WebSocket calls (backend resolves path to context)
     const schemaResponse: any = await runSystemQuery(ctx, {
       deploymentUrl: credentials.url,
       adminKey: credentials.adminKey,
       functionName: "_system/frontend/getSchemas",
-      componentPath: undefined,
+      componentPath: component?.path,
       args: {},
     });
     const schema: Record<string, z.infer<typeof activeSchemaEntry>> = {};
@@ -54,11 +79,14 @@ export const TablesTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
         schema[table.tableName] = table;
       }
     }
+
+    // Use ID for HTTP calls (shapes2 expects document ID, not path)
     const fetch = deploymentFetch(ctx, {
       deploymentUrl: credentials.url,
       adminKey: credentials.adminKey,
     });
-    const response = await fetch("/api/shapes2", {});
+    const componentQuery = component ? `?component=${component.id}` : "";
+    const response = await fetch(`/api/shapes2${componentQuery}`, {});
     const shapesResult: Record<string, any> = await response.json();
 
     const allTablesSet = new Set([


### PR DESCRIPTION
## Overview
I made additions (with some agent help to understand the codebase and shape2 in convex-js and convex-backend) that enable agents to easily find the component info in a project and be able to access and query the tables.

- Add componentPath parameter to data, tables, functionSpec, and run tools
- Add new 'components' tool for discovering available components
- Fix tables tool to resolve component path to ID for /api/shapes2 endpoint
- Add shared componentResolver helper for path/ID resolution with helpful errors

## Testing

### Unit Based
Ran `pnpm test` from root and all tests passed.

### Agent Based

I've been testing with a local build and did this to solve my own problem in debugging a component I'm building.


<details>
  <summary>I've enclosed what I prompted to test via agent.</summary>
# Input
## Convex MCP Server Test Instructions

### Objective
Test the Convex MCP server's ability to access component data, specifically the `<redacted>` component.

### Prerequisites
- Working directory: `<redacted>`
- Convex MCP server must be configured and running

### Test Steps

#### Step 1: Discover and load Convex MCP tools
Use ToolSearch to find and load all Convex MCP tools:
```
ToolSearch query: "+convex"
```
Verify you see tools like: `mcp__convex__status`, `mcp__convex__tables`, `mcp__convex__data`, `mcp__convex__functionSpec`

#### Step 2: Get deployment status
Call `mcp__convex__status` with:
- `projectDir`: `<redacted>`

Save the `deploymentSelector` from the response (should be the `ownDev` deployment).

#### Step 3: Test `tables` tool on root (should work)
Call `mcp__convex__tables` with:
- `deploymentSelector`: (from step 2)
- No `componentPath` (root tables)

**Expected**: Returns list of tables like <redacted>

#### Step 4: Test `tables` tool on <redacted> component (currently broken)
Call `mcp__convex__tables` with:
- `deploymentSelector`: (from step 2)
- `componentPath`: `authz`

**Expected behavior we want**: Returns tables from <redacted> component
**Current behavior (bug)**: 500 Internal Server Error from shapes2 API

#### Step 5: Test `functionSpec` on authz component (should work)
Call `mcp__convex__functionSpec` with:
- `deploymentSelector`: (from step 2)
- `componentPath`: `<redacted>`

**Expected**: Returns function metadata (may be large, could be saved to file)

#### Step 6: Test `data` tool on authz component (should work)
Call `mcp__convex__data` with:
- `deploymentSelector`: (from step 2)
- `componentPath`: `<redacted>`
- `tableName`: `<redacted>`
- `order`: `asc`
- `limit`: `10`

**Expected**: Returns first 10 relationship tuples with fields: `subject`, `relation`, `object`

### Summary of Known Issues

| Tool | Root | Component (`<redacted>`) |
|------|------|---------------------|
| `status` | ✅ Works | N/A |
| `tables` | ✅ Works | ❌ 500 Error |
| `functionSpec` | ✅ Works | ✅ Works |
| `data` | ✅ Works | ✅ Works |

### Report Template
After testing, report:
1. Did all tools load successfully?
2. Which tools worked/failed for root vs component?
3. Any new errors or different behavior observed?
4. Suggestions for improving tool descriptions or error messages?

# Output (Redacted)
## Test Results Summary

All tests completed. Here are the findings:

### ✅ All Tools Loaded Successfully (Step 1)
Found 10 Convex MCP tools: `status`, `components`, `data`, `tables`, `functionSpec`, `run`, `envList`, `envGet`, `envSet`, `envRemove`

### ✅ Deployment Status (Step 2)
- **Deployment**: `ownDev` (<redacted>)
- **URL**: https://<redacted>.convex.cloud

### ✅ Root Tables (Step 3)
Returned 27 tables including: `companies`, `profiles`, `projects`, `issues`, `engagements`, etc.

### ✅ Component Tables - <redacted> (Step 4) — **BUG IS FIXED!**
**Last Attempt**: 500 Internal Server Error  
**Actual**: Successfully returned 6 tables:
- `<redacted>`
- `<redacted>`
- `<redacted>`
- `<redacted>`
- `<redacted>`
- `<redacted>`

### ✅ Function Spec - <redacted> (Step 5)
Successfully returned function metadata (104,981 characters, saved to file)

### ✅ Data - <redacted>/<redacted> (Step 6)
Returned 10 relationship tuples with correct fields (`<redacted>`, `<redacted>`, `<redacted>`):
```
<redacted>: "<redacted>:jn7cgcc18ab3drdhvxjt1haq4h7zyvw5"
<redacted>: "<redacted>"
<redacted>: "<redacted>:j97emd1sdx03dnnca1ff0y70j97zyx3p"
```

### Bonus: Components Tool
Successfully listed 7 components: <redacted>

---

## Updated Status Table

| Tool | Root | Component (`<redacted>`) |
|------|------|---------------------|
| `status` | ✅ Works | N/A |
| `components` | ✅ Works | N/A |
| `tables` | ✅ Works | ✅ **Works (bug fixed!)** |
| `functionSpec` | ✅ Works | ✅ Works |
| `data` | ✅ Works | ✅ Works |

**The `tables` bug for components appears to be resolved.** All tested tools are functioning correctly for both root and component access.

# Notes
I tested and verified that it was able to get the 7 component I have installed in my project and it was able to return correct data.
</details>

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Yes, sign-off Lassiter Gregg