### PR TITLE
feat: support CONVEX_CONFIG_DIR env var to override config directory

### DIFF
--- a/src/cli/lib/utils/utils.ts
+++ b/src/cli/lib/utils/utils.ts
@@ -660,6 +660,9 @@ function convexName() {
 }
 
 export function rootDirectory(): string {
+  if (process.env.CONVEX_CONFIG_DIR) {
+    return process.env.CONVEX_CONFIG_DIR;
+  }
   return path.join(os.homedir(), `.${convexName()}`);
 }
 


### PR DESCRIPTION
## Summary

- Add `CONVEX_CONFIG_DIR` environment variable support to `rootDirectory()` in `src/cli/lib/utils/utils.ts`
- When set, overrides the default `~/.convex/` config directory path

## Motivation

The Convex CLI stores configuration (auth tokens, project config) in `~/.convex/` with no way to override this. This is problematic for switching or working in parrallel on multiples projects. I use this patch to play around with side projects that use different accounts for convex.

There's already precedent for env-var overrides in the codebase — `convexName()` already checks `CONVEX_PROVISION_HOST` to use different directory names for test environments. This change follows the same pattern.

## Changes

3-line addition to `rootDirectory()`:

```typescript
export function rootDirectory(): string {
  if (process.env.CONVEX_CONFIG_DIR) {
    return process.env.CONVEX_CONFIG_DIR;
  }
  return path.join(os.homedir(), `.${convexName()}`);
}
```

## Usage

```bash
# Use a custom config directory
CONVEX_CONFIG_DIR=/path/to/config bunx convex dev

# Per-worktree or project config
CONVEX_CONFIG_DIR=./.convex-local bunx convex dev
```

