### PR TITLE
Fix tsGo typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
   [TypeScript native preview](https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/)
   ([TypeScript 7](https://devblogs.microsoft.com/typescript/typescript-native-port/)).
   To do so, add `@typescript/native-preview` as a dev dependency and
-  [set `typescriptCompiler: "tsGo"` in `convex.json`](https://docs.convex.dev/production/project-configuration#configuring-the-typescript-compiler).
+  [set `typescriptCompiler: "tsgo"` in `convex.json`](https://docs.convex.dev/production/project-configuration#configuring-the-typescript-compiler).
 
 ## 1.31.0
 


### PR DESCRIPTION
### Fix [typo](https://github.com/get-convex/convex-js/blob/main/CHANGELOG.md#1311) in changelog: 
`tsGo` should be `tsgo` for the `typescriptCompiler` option in `convex.json`.
```
✖ `typescriptCompiler` in `convex.json`: Invalid enum value. Expected 'tsc' | 'tsgo', received 'tsGo'
✖ Error: Unable to read project config file "convex.json"
  Are you running this command from the root directory of a Convex project? If so, run `npx convex dev` first.
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
