### PR TITLE
fix: respect --env-file when writing env vars

### DIFF
--- a/src/cli/lib/deployment.ts
+++ b/src/cli/lib/deployment.ts
@@ -48,9 +48,11 @@ export async function writeDeploymentEnvVar(
     deploymentName: string;
   },
   existingValue: string | null,
+  envFile?: string | undefined,
 ): Promise<{ wroteToGitIgnore: boolean; changedDeploymentEnvVar: boolean }> {
-  const existingFile = ctx.fs.exists(ENV_VAR_FILE_PATH)
-    ? ctx.fs.readUtf8File(ENV_VAR_FILE_PATH)
+  const targetFile = envFile ?? ENV_VAR_FILE_PATH;
+  const existingFile = ctx.fs.exists(targetFile)
+    ? ctx.fs.readUtf8File(targetFile)
     : null;
   const changedFile = changesToEnvVarFile(
     existingFile,
@@ -67,7 +69,7 @@ export async function writeDeploymentEnvVar(
     existingValue !== deploymentEnvVarValue;
 
   if (changedFile !== null) {
-    ctx.fs.writeUtf8File(ENV_VAR_FILE_PATH, changedFile);
+    ctx.fs.writeUtf8File(targetFile, changedFile);
     // Only do this if we're not reinitializing an existing setup
     return {
       wroteToGitIgnore: await gitIgnoreEnvVarFile(ctx),
@@ -81,9 +83,13 @@ export async function writeDeploymentEnvVar(
 }
 
 // Only used in the internal --url flow
-export async function eraseDeploymentEnvVar(ctx: Context): Promise<boolean> {
-  const existingFile = ctx.fs.exists(ENV_VAR_FILE_PATH)
-    ? ctx.fs.readUtf8File(ENV_VAR_FILE_PATH)
+export async function eraseDeploymentEnvVar(
+  ctx: Context,
+  envFile?: string | undefined,
+): Promise<boolean> {
+  const targetFile = envFile ?? ENV_VAR_FILE_PATH;
+  const existingFile = ctx.fs.exists(targetFile)
+    ? ctx.fs.readUtf8File(targetFile)
     : null;
   if (existingFile === null) {
     return false;
@@ -97,7 +103,7 @@ export async function eraseDeploymentEnvVar(ctx: Context): Promise<boolean> {
     getEnvVarRegex(CONVEX_DEPLOYMENT_ENV_VAR_NAME),
     "",
   );
-  ctx.fs.writeUtf8File(ENV_VAR_FILE_PATH, changedFile);
+  ctx.fs.writeUtf8File(targetFile, changedFile);
   return true;
 }
 

--- a/src/cli/lib/envvars.ts
+++ b/src/cli/lib/envvars.ts
@@ -49,6 +49,7 @@ export async function writeUrlsToEnvFile(
   options: {
     convexUrl: string;
     siteUrl?: string | null | undefined;
+    envFile?: string | undefined;
   },
 ): Promise<EnvFileUrlConfig> {
   const envFileConfig = await loadEnvFileUrlConfig(ctx, options);
@@ -243,12 +244,15 @@ async function loadEnvFileUrlConfig(
   options: {
     convexUrl: string;
     siteUrl?: string | null | undefined;
+    envFile?: string | undefined;
   },
 ): Promise<EnvFileUrlConfig> {
   const { detectedFramework, convexUrlEnvVar, convexSiteEnvVar } =
     await suggestedEnvVarNames(ctx);
 
-  const { envFile, existing } = suggestedDevEnvFile(ctx, detectedFramework);
+  const { envFile, existing } = options.envFile
+    ? { envFile: options.envFile, existing: ctx.fs.exists(options.envFile) }
+    : suggestedDevEnvFile(ctx, detectedFramework);
 
   if (!existing) {
     return {

--- a/src/cli/lib/init.ts
+++ b/src/cli/lib/init.ts
@@ -15,11 +15,13 @@ export async function finalizeConfiguration(
     siteUrl: string | null | undefined;
     wroteToGitIgnore: boolean;
     changedDeploymentEnvVar: boolean;
+    envFile?: string | undefined;
   },
 ) {
   const envFileConfig = await writeUrlsToEnvFile(ctx, {
     convexUrl: options.url,
     siteUrl: options.siteUrl,
+    envFile: options.envFile,
   });
   const isEnvFileConfigChanged =
     envFileConfig !== null &&
@@ -45,7 +47,7 @@ export async function finalizeConfiguration(
     );
   } else if (options.changedDeploymentEnvVar) {
     logFinishedStep(
-      `${messageForDeploymentType(options.deploymentType, options.url)} and saved its name as CONVEX_DEPLOYMENT to .env.local`,
+      `${messageForDeploymentType(options.deploymentType, options.url)} and saved its name as CONVEX_DEPLOYMENT to ${options.envFile ?? ".env.local"}`,
     );
   }
   if (options.wroteToGitIgnore) {


### PR DESCRIPTION
## Summary

- Problem: The `--env-file` option is only used for **reading** deployment config (in `deploymentSelection.ts`), but when **writing** `CONVEX_DEPLOYMENT`, `CONVEX_URL`, etc., the CLI always writes to the hardcoded `.env.local`
- Fix: Thread the `envFile` option through `writeDeploymentEnvVar`, `eraseDeploymentEnvVar`, `writeUrlsToEnvFile`, and `finalizeConfiguration` so that when `--env-file` is specified, writes go to that file instead
- Update log messages to display the actual target file instead of hardcoded `.env.local`

## Test plan

- [ ] Run `CONVEX_AGENT_MODE=anonymous npx convex dev --env-file .env.custom` and confirm `CONVEX_DEPLOYMENT` is written to `.env.custom` instead of `.env.local`
- [ ] Run `npx convex dev` without `--env-file` and confirm default `.env.local` behavior is unchanged
- [ ] Existing tests pass (`deployment.test.ts`, `run.test.ts`, `utils.test.ts`)

