### PR TITLE
Remove template from ConvexProviderWithClerk

### DIFF
--- a/src/react-clerk/ConvexProviderWithClerk.tsx
+++ b/src/react-clerk/ConvexProviderWithClerk.tsx
@@ -15,8 +15,7 @@ type IConvexReactClient = {
 type UseAuth = () => {
   isLoaded: boolean;
   isSignedIn: boolean | undefined;
-  getToken: (options: {
-    template?: "convex";
+  getToken: (options?: {
     skipCache?: boolean;
   }) => Promise<string | null>;
   // We don't use these properties but they should trigger a new token fetch.
@@ -64,7 +63,6 @@ function useUseAuthFromClerk(useAuth: UseAuth) {
           async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
             try {
               return await getToken({
-                template: "convex",
                 skipCache: forceRefreshToken,
               });
             } catch {


### PR DESCRIPTION
<!-- Describe your PR here. -->
:wave: Hey all! The new Clerk+Convex integration is live! This means that going forward, developers using convex with clerk no longer need to create or use custom clerk jwt templates. Once they've activated the integration, the required aud claim will be included with the default clerk jwt.

For reference, here are the  [Clerk docs on setting up the new integration](https://clerk.com/docs/guides/development/integrations/databases/convex).

Not in this PR: [These docs](https://docs.convex.dev/auth/clerk) that instruct developers to setup a custom jwt template should also be updated.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.