### PR TITLE
cli: add interactive min-length validation for project name

### DIFF
--- a/src/cli/configure.ts
+++ b/src/cli/configure.ts
@@ -533,6 +533,16 @@ export async function selectProject(
 }
 
 const cwd = path.basename(process.cwd());
+
+function validateProjectName(value: string): true | string {
+  const minProjectNameLength = 3;
+  const projectName = value.trim();
+  if (projectName.length < minProjectNameLength) {
+    return `Project name must be at least ${minProjectNameLength} characters.`;
+  }
+  return true;
+}
+
 async function selectNewProject(
   ctx: Context,
   chosenConfiguration: ChosenConfiguration,
@@ -553,6 +563,7 @@ async function selectNewProject(
     projectName = await promptString(ctx, {
       message: "Project name:",
       default: config.defaultProjectName || cwd,
+      validate: validateProjectName,
     });
     choseProjectInteractively = true;
   }


### PR DESCRIPTION
Add validation to the project name in cli.

This avoids the backend API error "InvalidProjectName: Project name must be at least 3 characters long." which currently forces users to re-enter all inputs.