### PR TITLE
Fix Clerk session refresh auth

### DIFF
--- a/src/react-clerk/ConvexProviderWithClerk.tsx
+++ b/src/react-clerk/ConvexProviderWithClerk.tsx
@@ -22,6 +22,7 @@ type UseAuth = () => {
   // We don't use these properties but they should trigger a new token fetch.
   orgId: string | undefined | null;
   orgRole: string | undefined | null;
+  sessionId: string | undefined | null;
   sessionClaims: Record<string, unknown> | undefined | null;
 };
 
@@ -66,6 +67,7 @@ function useUseAuthFromClerk(useAuth: UseAuth) {
           getToken,
           orgId,
           orgRole,
+          sessionId,
           sessionClaims,
         } = useAuth();
         const fetchAccessToken = useCallback(
@@ -91,7 +93,7 @@ function useUseAuthFromClerk(useAuth: UseAuth) {
           // Anything else from the JWT Clerk wants to be reactive goes here too.
           // Clerk's Expo useAuth hook is not memoized so we don't include getToken.
           // eslint-disable-next-line react-hooks/exhaustive-deps
-          [orgId, orgRole],
+          [orgId, orgRole, sessionId],
         );
         return useMemo(
           () => ({


### PR DESCRIPTION
## Summary

Fix `ConvexProviderWithClerk` so Clerk session replacement triggers Convex auth setup again.

The Clerk adapter already rebuilds its token fetcher when org context changes, but it does not currently react to Clerk `sessionId` changes. In Expo apps using `@clerk/expo`, signing out and signing back in can replace the Clerk session while Convex keeps using the previous token fetch closure. This can leave `useConvexAuth()` loaded but unauthenticated until the app reloads or the provider is manually remounted.

Fixes #156.

## Changes

- Include Clerk `sessionId` in the auth context values that rebuild `fetchAccessToken`.
- Preserve the existing behavior of not depending on `getToken`, since Clerk Expo’s `useAuth` hook is not memoized and previously caused an auth loop.

## Follow-up note

I noticed `fetchAccessToken` also reads `sessionClaims?.aud` without including a primitive derived value in the callback dependencies. I left that unchanged here to keep this PR scoped to Clerk session replacement, but it may be worth considering separately if the Convex integration/JWT-template mode can change during a mounted provider lifetime.

## Verification

- `npm run typecheck -- --pretty false`
- `npm run build`
