### PR TITLE
Sort import paths identically on POSIX vs. Windows

### DIFF
--- a/src/cli/lib/codegen.ts
+++ b/src/cli/lib/codegen.ts
@@ -44,7 +44,7 @@ import {
   componentTS,
   rootComponentApiCJS,
 } from "../codegen_templates/component_api.js";
-import { functionsDir } from "./utils/utils.js";
+import { functionsDir, sorted } from "./utils/utils.js";
 import { LargeIndexDeletionCheck } from "./indexes.js";
 
 const PRESERVED_GENERATED_ENTRIES = new Set(["ai"]);
@@ -844,9 +844,11 @@ async function doApiCodegen(
   opts?: { dryRun?: boolean; debug?: boolean },
 ) {
   const absModulePaths = await entryPoints(ctx, functionsDir);
-  const modulePaths = absModulePaths
-    .map((p) => path.relative(functionsDir, p))
-    .sort();
+  // Sort paths as generic (forward slash) for identical results on POSIX and Windows.
+  const modulePaths = sorted(
+    absModulePaths.map((p) => path.relative(functionsDir, p)),
+    (p) => p.replaceAll("\\", "/"),
+  );
 
   const writtenFiles: string[] = [];
 


### PR DESCRIPTION
This should fix a problem reported by @timukasr to the Convex Discord:

> Hey, I found that generated `api.d.ts` order differs on Windows vs POSIX in Convex 1.38.0 (and earlier).
> Linux:
> ```ts
> import type * as auth_ensure from "../auth/ensure.js";
> import type * as authSchema from "../authSchema.js";
> ```
> Windows:
> ```ts
> import type * as authSchema from "../authSchema.js";
> import type * as auth_ensure from "../auth/ensure.js";
> ```
> A bit annoying when team members use different OS

> just running `npx convex dev`, for example
> * run `npx convex dev` on linux, `api.d.ts` changes
> * commit
> * pull on windows
> * run `npx convex dev`
> * `api.d.ts` changes again

The import paths are sorted with `sort()`, comparing their string contents:

https://github.com/get-convex/convex-js/blob/1a64ab88a65ddd8418ac38925d873a2bd9227523/src/cli/lib/codegen.ts#L847-L849

Then they're printed in that order:
https://github.com/get-convex/convex-js/blob/1a64ab88a65ddd8418ac38925d873a2bd9227523/src/cli/codegen_templates/api.ts#L140-L147

And they're printed in generic format (i.e. with forward slashes; I don't know if TypeScript devs use this terminology, but that's what we call it over in [C++ `<filesystem>`](https://cppreference.com/cpp/filesystem/path) which abstracts away the differences between POSIX and Windows):
https://github.com/get-convex/convex-js/blob/1a64ab88a65ddd8418ac38925d873a2bd9227523/src/cli/codegen_templates/api.ts#L3-L9

The root cause is that the `sort()` is performed based on the native format with varying backslash/forward-slash content, even though the final result is printed in generic format. ASCII sort order is forward slash `/` (decimal 47), digits `0`-`9` (decimal 48-57), uppercase `A`-`Z` (decimal 65-90), backslash `\` (decimal 92), lowercase `a`-`z` (decimal 97-122). This is why in the original example, which compares `"../auth/ensure.js"` to `"../authSchema.js"`, Linux sorts the path separator first (forward slash `/` is less than uppercase `S`), but Windows sorts the path separator last (uppercase `S` is less than backslash `\`).

Convex's `utils.ts` has a `sorted` function which makes it easy to create a sorted copy of an array, where the sorting is viewed through some transformation:

https://github.com/get-convex/convex-js/blob/1a64ab88a65ddd8418ac38925d873a2bd9227523/src/cli/lib/utils/utils.ts#L655-L664

I've chosen to use that here to be minimally intrusive (as opposed to immediately converting the contents to generic format, which might also work, but validating that is beyond my ability).

I believe ES2021's `replaceAll` is available, so I'm using that instead of `replace` with a global regex:
https://github.com/get-convex/convex-js/blob/1a64ab88a65ddd8418ac38925d873a2bd9227523/tsconfig.json#L6

I wrote this from scratch, checking its behavior with a self-contained test case, but I haven't validated Convex's behavior end-to-end here.

<details><summary>Click to expand self-contained test case on Windows:</summary>

```
C:\Temp>type sort-paths.ts
```
```ts
import path from "path";

const paths = [
  path.join("..", "auth", "ensure.js"),
  path.join("..", "authSchema.js"),
];

function compareAsGenericPaths(a: string, b: string) {
  const x = a.replaceAll("\\", "/");
  const y = b.replaceAll("\\", "/");
  return x < y ? -1 : x > y ? 1 : 0;
}

console.log("Default sorting behavior:");
for (const p of [...paths].sort()) {
  console.log(p);
}
console.log();
console.log("Sorting with compareAsGenericPaths:");
for (const p of [...paths].sort(compareAsGenericPaths)) {
  console.log(p);
}
```
```
C:\Temp>node sort-paths.ts
Default sorting behavior:
..\authSchema.js
..\auth\ensure.js

Sorting with compareAsGenericPaths:
..\auth\ensure.js
..\authSchema.js
```
</details>

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
