### PR TITLE
Retry mutations that fail due to OCC write conflicts once (by default) and make configurable in HTTP client, WebSocket client, and action context

### DIFF
--- a/src/browser/http_client.ts
+++ b/src/browser/http_client.ts
@@ -23,6 +23,12 @@ import {
   FunctionArgs,
   UserIdentityAttributes,
 } from "../server/index.js";
+import {
+  retryOnWriteConflict,
+  validateWriteConflictRetryOptions,
+  ValidatedWriteConflictRetryOptions,
+  WriteConflictRetryOptions,
+} from "../common/write_conflict_retry.js";
 
 export const STATUS_CODE_OK = 200;
 export const STATUS_CODE_BAD_REQUEST = 400;
@@ -37,14 +43,14 @@ export function setFetch(f: typeof globalThis.fetch) {
   specifiedFetch = f;
 }
 
-export type HttpMutationOptions = {
+export type HttpMutationOptions = WriteConflictRetryOptions & {
   /**
    * Skip the default queue of mutations and run this immediately.
    *
    * This allows the same HttpConvexClient to be used to request multiple
    * mutations in parallel, something not possible with WebSocket-based clients.
    */
-  skipQueue: boolean;
+  skipQueue?: boolean | undefined;
 };
 
 /**
@@ -70,6 +76,7 @@ export class ConvexHttpClient {
   private mutationQueue: Array<{
     mutation: FunctionReference<"mutation">;
     args: FunctionArgs<any>;
+    writeConflictRetryOptions: ValidatedWriteConflictRetryOptions;
     resolve: (value: any) => void;
     reject: (error: any) => void;
   }> = [];
@@ -342,6 +349,19 @@ export class ConvexHttpClient {
   private async mutationInner<Mutation extends FunctionReference<"mutation">>(
     mutation: Mutation,
     mutationArgs: FunctionArgs<Mutation>,
+    writeConflictRetryOptions: ValidatedWriteConflictRetryOptions,
+  ): Promise<FunctionReturnType<Mutation>> {
+    return await retryOnWriteConflict(
+      () => this.mutationInnerOnce(mutation, mutationArgs),
+      writeConflictRetryOptions,
+    );
+  }
+
+  private async mutationInnerOnce<
+    Mutation extends FunctionReference<"mutation">,
+  >(
+    mutation: Mutation,
+    mutationArgs: FunctionArgs<Mutation>,
   ): Promise<FunctionReturnType<Mutation>> {
     const name = getFunctionName(mutation);
     const body = JSON.stringify({
@@ -397,9 +417,14 @@ export class ConvexHttpClient {
 
     this.isProcessingQueue = true;
     while (this.mutationQueue.length > 0) {
-      const { mutation, args, resolve, reject } = this.mutationQueue.shift()!;
+      const { mutation, args, writeConflictRetryOptions, resolve, reject } =
+        this.mutationQueue.shift()!;
       try {
-        const result = await this.mutationInner(mutation, args);
+        const result = await this.mutationInner(
+          mutation,
+          args,
+          writeConflictRetryOptions,
+        );
         resolve(result);
       } catch (error) {
         reject(error);
@@ -411,9 +436,16 @@ export class ConvexHttpClient {
   private enqueueMutation<Mutation extends FunctionReference<"mutation">>(
     mutation: Mutation,
     args: FunctionArgs<Mutation>,
+    writeConflictRetryOptions: ValidatedWriteConflictRetryOptions,
   ): Promise<FunctionReturnType<Mutation>> {
     return new Promise((resolve, reject) => {
-      this.mutationQueue.push({ mutation, args, resolve, reject });
+      this.mutationQueue.push({
+        mutation,
+        args,
+        writeConflictRetryOptions,
+        resolve,
+        reject,
+      });
       void this.processMutationQueue();
     });
   }
@@ -434,11 +466,21 @@ export class ConvexHttpClient {
     const [fnArgs, options] = args;
     const mutationArgs = parseArgs(fnArgs);
     const queued = !options?.skipQueue;
+    const writeConflictRetryOptions =
+      validateWriteConflictRetryOptions(options);
 
     if (queued) {
-      return await this.enqueueMutation(mutation, mutationArgs);
+      return await this.enqueueMutation(
+        mutation,
+        mutationArgs,
+        writeConflictRetryOptions,
+      );
     } else {
-      return await this.mutationInner(mutation, mutationArgs);
+      return await this.mutationInner(
+        mutation,
+        mutationArgs,
+        writeConflictRetryOptions,
+      );
     }
   }
 

--- a/src/browser/sync/client.ts
+++ b/src/browser/sync/client.ts
@@ -24,6 +24,12 @@ import {
   OptimisticUpdate,
 } from "./optimistic_updates.js";
 import {
+  isWriteConflictRetryableResult,
+  sleepForWriteConflictRetry,
+  validateWriteConflictRetryOptions,
+  WriteConflictRetryOptions,
+} from "../../common/write_conflict_retry.js";
+import {
   OptimisticQueryResults,
   QueryResultsMap,
 } from "./optimistic_updates_impl.js";
@@ -200,7 +206,7 @@ export interface SubscribeOptions {
  *
  * @public
  */
-export interface MutationOptions {
+export interface MutationOptions extends WriteConflictRetryOptions {
   /**
    * An optimistic update to apply along with this mutation.
    *
@@ -885,13 +891,29 @@ export class BaseConvexClient {
     options?: MutationOptions,
     componentPath?: string,
   ): Promise<FunctionResult> {
-    const { mutationPromise } = this.enqueueMutation(
-      udfPath,
-      args,
-      options,
-      componentPath,
-    );
-    return mutationPromise;
+    const writeConflictRetryOptions =
+      validateWriteConflictRetryOptions(options);
+    let retriesRemaining = writeConflictRetryOptions.maxWriteConflictRetries;
+    while (true) {
+      const { mutationPromise } = this.enqueueMutation(
+        udfPath,
+        args,
+        options,
+        componentPath,
+      );
+      const result = await mutationPromise;
+      if (
+        retriesRemaining <= 0 ||
+        !isWriteConflictRetryableResult(result) ||
+        this.webSocketManager.socketState() === "terminated"
+      ) {
+        return result;
+      }
+      retriesRemaining -= 1;
+      await sleepForWriteConflictRetry(
+        writeConflictRetryOptions.writeConflictRetryDelayMs,
+      );
+    }
   }
 
   /**

--- a/src/common/write_conflict_retry.test.ts
+++ b/src/common/write_conflict_retry.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  isWriteConflictRetryableMessage,
+  retryOnWriteConflict,
+  validateMaxWriteConflictRetries,
+  validateWriteConflictRetryDelayMs,
+} from "./write_conflict_retry.js";
+
+describe("write conflict retries", () => {
+  test("matches Convex write conflict messages", () => {
+    expect(
+      isWriteConflictRetryableMessage("OptimisticConcurrencyControlFailure"),
+    ).toBe(true);
+    expect(
+      isWriteConflictRetryableMessage(
+        'Documents read from or written to the "users" table changed while this mutation was being run and on every subsequent retry.',
+      ),
+    ).toBe(true);
+    expect(isWriteConflictRetryableMessage("Validation failed")).toBe(false);
+  });
+
+  test("validates retry counts", () => {
+    expect(validateMaxWriteConflictRetries(undefined)).toBe(1);
+    expect(
+      validateMaxWriteConflictRetries({ maxWriteConflictRetries: 0 }),
+    ).toBe(0);
+    expect(
+      validateMaxWriteConflictRetries({ maxWriteConflictRetries: 2 }),
+    ).toBe(2);
+    expect(() =>
+      validateMaxWriteConflictRetries({ maxWriteConflictRetries: -1 }),
+    ).toThrow("maxWriteConflictRetries must be a nonnegative integer.");
+  });
+
+  test("validates retry delays", () => {
+    expect(validateWriteConflictRetryDelayMs(undefined)).toBe(2000);
+    expect(
+      validateWriteConflictRetryDelayMs({ writeConflictRetryDelayMs: 0 }),
+    ).toBe(0);
+    expect(
+      validateWriteConflictRetryDelayMs({ writeConflictRetryDelayMs: 2500 }),
+    ).toBe(2500);
+    expect(() =>
+      validateWriteConflictRetryDelayMs({ writeConflictRetryDelayMs: -1 }),
+    ).toThrow("writeConflictRetryDelayMs must be a nonnegative number.");
+  });
+
+  test("retries write conflict errors", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const result = retryOnWriteConflict(
+      async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("OptimisticConcurrencyControlFailure");
+        }
+        return "ok";
+      },
+      {
+        maxWriteConflictRetries: 1,
+        writeConflictRetryDelayMs: 2000,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect(result).resolves.toBe("ok");
+    expect(calls).toBe(2);
+    vi.useRealTimers();
+  });
+
+  test("does not retry other errors", async () => {
+    let calls = 0;
+    await expect(
+      retryOnWriteConflict(
+        async () => {
+          calls += 1;
+          throw new Error("Validation failed");
+        },
+        {
+          maxWriteConflictRetries: 1,
+          writeConflictRetryDelayMs: 2000,
+        },
+      ),
+    ).rejects.toThrow("Validation failed");
+    expect(calls).toBe(1);
+  });
+});

--- a/src/common/write_conflict_retry.ts
+++ b/src/common/write_conflict_retry.ts
@@ -1,0 +1,117 @@
+const WRITE_CONFLICT_ERROR_TEXT = "OptimisticConcurrencyControlFailure";
+const WRITE_CONFLICT_PUBLIC_ERROR_TEXT = "Documents read from or written to";
+const WRITE_CONFLICT_PUBLIC_RETRY_TEXT =
+  "changed while this mutation was being run and on every subsequent retry";
+
+const DEFAULT_MAX_WRITE_CONFLICT_RETRIES = 1;
+const DEFAULT_WRITE_CONFLICT_RETRY_DELAY_MS = 2000;
+
+export interface WriteConflictRetryOptions {
+  /**
+   * The number of additional attempts to make after Convex reports a final
+   * write conflict for a mutation.
+   *
+   * Defaults to 1. Set to 0 to disable client-side or action-side write
+   * conflict retries.
+   */
+  maxWriteConflictRetries?: number | undefined;
+  /**
+   * The delay before each additional write conflict retry, in milliseconds.
+   *
+   * Defaults to 2000.
+   */
+  writeConflictRetryDelayMs?: number | undefined;
+}
+
+export type ValidatedWriteConflictRetryOptions = {
+  maxWriteConflictRetries: number;
+  writeConflictRetryDelayMs: number;
+};
+
+export function validateWriteConflictRetryOptions(
+  options: WriteConflictRetryOptions | undefined,
+): ValidatedWriteConflictRetryOptions {
+  return {
+    maxWriteConflictRetries: validateMaxWriteConflictRetries(options),
+    writeConflictRetryDelayMs: validateWriteConflictRetryDelayMs(options),
+  };
+}
+
+export function validateMaxWriteConflictRetries(
+  options: WriteConflictRetryOptions | undefined,
+): number {
+  const maxWriteConflictRetries =
+    options?.maxWriteConflictRetries ?? DEFAULT_MAX_WRITE_CONFLICT_RETRIES;
+  if (
+    !Number.isInteger(maxWriteConflictRetries) ||
+    maxWriteConflictRetries < 0
+  ) {
+    throw new Error("maxWriteConflictRetries must be a nonnegative integer.");
+  }
+  return maxWriteConflictRetries;
+}
+
+export function validateWriteConflictRetryDelayMs(
+  options: WriteConflictRetryOptions | undefined,
+): number {
+  const writeConflictRetryDelayMs =
+    options?.writeConflictRetryDelayMs ?? DEFAULT_WRITE_CONFLICT_RETRY_DELAY_MS;
+  if (
+    !Number.isFinite(writeConflictRetryDelayMs) ||
+    writeConflictRetryDelayMs < 0
+  ) {
+    throw new Error("writeConflictRetryDelayMs must be a nonnegative number.");
+  }
+  return writeConflictRetryDelayMs;
+}
+
+export function isWriteConflictRetryableMessage(message: string): boolean {
+  return (
+    message.includes(WRITE_CONFLICT_ERROR_TEXT) ||
+    (message.includes(WRITE_CONFLICT_PUBLIC_ERROR_TEXT) &&
+      message.includes(WRITE_CONFLICT_PUBLIC_RETRY_TEXT))
+  );
+}
+
+export function isWriteConflictRetryableError(error: unknown): boolean {
+  return (
+    error instanceof Error && isWriteConflictRetryableMessage(error.message)
+  );
+}
+
+export function isWriteConflictRetryableResult(result: {
+  success: boolean;
+  errorMessage?: string;
+}): boolean {
+  return (
+    !result.success &&
+    result.errorMessage !== undefined &&
+    isWriteConflictRetryableMessage(result.errorMessage)
+  );
+}
+
+export async function sleepForWriteConflictRetry(
+  delayMs: number,
+): Promise<void> {
+  return await new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+export async function retryOnWriteConflict<T>(
+  operation: () => Promise<T>,
+  options: ValidatedWriteConflictRetryOptions,
+): Promise<T> {
+  let attemptsRemaining = options.maxWriteConflictRetries;
+  while (true) {
+    try {
+      return await operation();
+    } catch (error: unknown) {
+      if (attemptsRemaining <= 0 || !isWriteConflictRetryableError(error)) {
+        throw error;
+      }
+      attemptsRemaining -= 1;
+      await sleepForWriteConflictRetry(options.writeConflictRetryDelayMs);
+    }
+  }
+}

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -45,6 +45,7 @@
 
 import { ConvexHttpClient } from "../browser/index.js";
 import { validateDeploymentUrl } from "../common/index.js";
+import type { WriteConflictRetryOptions } from "../common/write_conflict_retry.js";
 import { Preloaded } from "../react/index.js";
 import {
   ArgsAndOptions,
@@ -85,6 +86,11 @@ export type NextjsOptions = {
    */
   skipConvexDeploymentUrlCheck?: boolean;
 };
+
+/**
+ * Options to {@link fetchMutation}.
+ */
+export type NextjsMutationOptions = NextjsOptions & WriteConflictRetryOptions;
 
 /**
  * Execute a Convex query function and return a `Preloaded`
@@ -156,11 +162,14 @@ export async function fetchMutation<
   Mutation extends FunctionReference<"mutation">,
 >(
   mutation: Mutation,
-  ...args: ArgsAndOptions<Mutation, NextjsOptions>
+  ...args: ArgsAndOptions<Mutation, NextjsMutationOptions>
 ): Promise<FunctionReturnType<Mutation>> {
   const [fnArgs, options] = args;
   const client = setupClient(options ?? {});
-  return client.mutation(mutation, fnArgs || {});
+  return client.mutation(mutation, fnArgs || {}, {
+    maxWriteConflictRetries: options?.maxWriteConflictRetries,
+    writeConflictRetryDelayMs: options?.writeConflictRetryDelayMs,
+  });
 }
 
 /**

--- a/src/react/client.ts
+++ b/src/react/client.ts
@@ -17,6 +17,7 @@ import type { UserIdentityAttributes } from "../browser/sync/protocol.js";
 import { RequestForQueries, useQueries } from "./use_queries.js";
 import { useSubscription } from "./use_subscription.js";
 import { parseArgs } from "../common/index.js";
+import type { WriteConflictRetryOptions } from "../common/write_conflict_retry.js";
 import {
   ArgsAndOptions,
   FunctionArgs,
@@ -59,9 +60,12 @@ export interface ReactMutation<Mutation extends FunctionReference<"mutation">> {
    * Execute the mutation on the server, returning a `Promise` of its return value.
    *
    * @param args - Arguments for the mutation to pass up to the server.
+   * @param options - Options for this mutation invocation.
    * @returns The return value of the server-side function call.
    */
-  (...args: OptionalRestArgs<Mutation>): Promise<FunctionReturnType<Mutation>>;
+  (
+    ...args: ArgsAndOptions<Mutation, WriteConflictRetryOptions>
+  ): Promise<FunctionReturnType<Mutation>>;
 
   /**
    * Define an optimistic update to apply as part of this mutation.
@@ -98,11 +102,16 @@ export function createMutation(
   client: ConvexReactClient,
   update?: OptimisticUpdate<any>,
 ): ReactMutation<any> {
-  function mutation(args?: Record<string, Value>): Promise<unknown> {
+  function mutation(
+    args?: Record<string, Value>,
+    options?: WriteConflictRetryOptions,
+  ): Promise<unknown> {
     assertNotAccidentalArgument(args);
 
     return client.mutation(mutationReference, args, {
       optimisticUpdate: update,
+      maxWriteConflictRetries: options?.maxWriteConflictRetries,
+      writeConflictRetryDelayMs: options?.writeConflictRetryDelayMs,
     });
   }
   mutation.withOptimisticUpdate = function withOptimisticUpdate(
@@ -280,6 +289,19 @@ export interface MutationOptions<Args extends Record<string, Value>> {
    * Once the mutation completes, the update will be rolled back.
    */
   optimisticUpdate?: OptimisticUpdate<Args> | undefined;
+  /**
+   * The number of additional attempts to make after Convex reports a final
+   * write conflict for this mutation.
+   *
+   * Defaults to 1. Set to 0 to disable client-side write conflict retries.
+   */
+  maxWriteConflictRetries?: number | undefined;
+  /**
+   * The delay before each additional write conflict retry, in milliseconds.
+   *
+   * Defaults to 2000.
+   */
+  writeConflictRetryDelayMs?: number | undefined;
 }
 
 /**

--- a/src/server/impl/actions_impl.ts
+++ b/src/server/impl/actions_impl.ts
@@ -4,6 +4,11 @@ import { performAsyncSyscall } from "./syscall.js";
 import { parseArgs } from "../../common/index.js";
 import { FunctionReference } from "../../server/api.js";
 import { getFunctionAddress } from "../components/paths.js";
+import {
+  retryOnWriteConflict,
+  validateWriteConflictRetryOptions,
+  WriteConflictRetryOptions,
+} from "../../common/write_conflict_retry.js";
 
 function syscallArgs(
   requestId: string,
@@ -34,10 +39,17 @@ export function setupActionCalls(requestId: string) {
     runMutation: async (
       mutation: FunctionReference<"mutation", "public" | "internal">,
       args?: Record<string, Value>,
+      options?: WriteConflictRetryOptions,
     ): Promise<any> => {
-      const result = await performAsyncSyscall(
-        "1.0/actions/mutation",
-        syscallArgs(requestId, mutation, args),
+      const writeConflictRetryOptions =
+        validateWriteConflictRetryOptions(options);
+      const result = await retryOnWriteConflict(
+        () =>
+          performAsyncSyscall(
+            "1.0/actions/mutation",
+            syscallArgs(requestId, mutation, args),
+          ),
+        writeConflictRetryOptions,
       );
       return jsonToConvex(result);
     },

--- a/src/server/impl/registration_impl.ts
+++ b/src/server/impl/registration_impl.ts
@@ -46,6 +46,18 @@ import {
   setupActionMeta,
 } from "./meta_impl.js";
 
+function transactionLimitsForMutationRunMutation(options: any) {
+  if (
+    options?.maxWriteConflictRetries !== undefined ||
+    options?.writeConflictRetryDelayMs !== undefined
+  ) {
+    throw new Error(
+      "Write conflict retry options are only supported for client mutations and ActionCtx.runMutation calls. MutationCtx.runMutation runs within the parent mutation transaction and is retried with the parent mutation.",
+    );
+  }
+  return options?.transactionLimits;
+}
+
 async function invokeMutation<
   F extends (ctx: GenericMutationCtx<GenericDataModel>, ...args: any) => any,
 >(func: F, argsStr: string, visibility: FunctionVisibility) {
@@ -65,7 +77,12 @@ async function invokeMutation<
         ? runUdf("snapshotQuery", reference, args, options?.transactionLimits)
         : runUdf("query", reference, args, options?.transactionLimits),
     runMutation: (reference: any, args?: any, options?: any) =>
-      runUdf("mutation", reference, args, options?.transactionLimits),
+      runUdf(
+        "mutation",
+        reference,
+        args,
+        transactionLimitsForMutationRunMutation(options),
+      ),
   };
   const result = await invokeFunction(func, mutationCtx, args as any);
   validateReturnValue(result);

--- a/src/server/registration.ts
+++ b/src/server/registration.ts
@@ -27,6 +27,7 @@ import {
   ObjectType,
   PropertyValidators,
 } from "../values/validator.js";
+import type { WriteConflictRetryOptions } from "../common/write_conflict_retry.js";
 import { Id } from "../values/value.js";
 import {
   GenericDataModel,
@@ -336,6 +337,9 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
    *
    * Each `runMutation` call is a separate write transaction. Consider using
    * an {@link internalMutation} to prevent users from calling it directly.
+   * If Convex reports a final write conflict, this call retries once by
+   * default. Pass `{ maxWriteConflictRetries: 0 }` as the final argument to
+   * disable this retry.
    *
    * @example
    * ```typescript
@@ -350,7 +354,7 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
     Mutation extends FunctionReference<"mutation", "public" | "internal">,
   >(
     mutation: Mutation,
-    ...args: OptionalRestArgs<Mutation>
+    ...args: ArgsAndOptions<Mutation, WriteConflictRetryOptions>
   ): Promise<FunctionReturnType<Mutation>>;
 
   /**


### PR DESCRIPTION
### Context

I wrote a few days ago [in Discord](https://discord.com/channels/1019350475847499849/1019350478817079338/1515369351346258100):

> 3) OCC write conflicts bite more than you think. Despite convex backend retries a mutation 4 times before failing it completely, this is surprisingly not a theoretical concern: some mutations do fail completely, jeopardising the app's correctness and data durability (wrapping all mutation calls in the clients and inside actions with retries of OCC write conflicts is a simple, last-line-of-defence mitigation that I think I should do and I think convex-js should have done by default; but even that won't save from all OCC write conflict failures).
> 
> My app is not a realtime game nor even a realtime group chat. It mostly integrates a ton of external fetches and webhooks and sets up crons and cascade/trigger update/actions between them. There are usually less than one action or mutation per second on average, definitely < 10 per second at worst imaginable bursts (and that bursts themselves could only be coincidental and couldn't last longer than a few seconds). Yet, when I open the Convex dashboard, I always see some "Failed due to write conflicts" errors there in the last day.

[And then](https://discord.com/channels/1019350475847499849/1515369361597268008/1516334752569757826):

> OCC write conflicts are surpirsingly non-wanishing/non-theoretical concern of one cares of not having them at all (but if the app's nature that failing 0.1% or 0.01% of mutations is fine that is probably not). After I wrote the above, I've put my money where my mouth is and actually implement a patch for get-convex/convex-js that patches ctx.runMutation, HTTP client mutation and WebSocket client mutation to retry the mutation once after 2000ms if the mutation call fails with "OptimisticConcurrencyControlFailure", because it seems to me that surprising commonality of "Failed due to write conflicts" is because the current default (4 retries with jitter after 0-100ms, 0-200ms, 0-400ms, or 0-800ms) is not a good tradeoff, at least for the kind of bursty patterns that I have. (I can share the patch.) Anectodally, since I did this, I got 3 new "Failed due to write conflicts" errors in insights, and each appears only once, which means my retry works (because if it was futile, each failure appeared an even number of times in insights: the first try and the retry).

### Results

After running the patch described above in production, there were **15 OCC write failures when mutations were run from either HTTP or WebSocket clients, or from the action context** (and more OCC write conflicts when mutations are started by the scheduler; but confusingly, scheduler has _indefinite_ retry policy, which itself might be a bug, see first comment to this PR with details).

**In 14 of those 15 cases, the retry helped: the retries mutation succeeded** in 2.3...2.7s seconds after the first mutation attempt failed (which is expected, because I've added 2 second delay between retries). In 15th case the results are unclear because hard to attribute Axiom logs definitely, but might have helped as well.

### Discussion

There was a wide variety of different mutations in question, not a single mutation and a single OCC write conflict pattern. Overall, my application is **not** a high-frequency, extremely high load realtime app: it has decently paced (such as once every 10s, once every 1min, etc.) crons, a ton of webhooks, and various triggers when certain events in certain crons or webhooks or actions from the frontend trigger some mutations. This kind of application I think is *realatively average*, not extreme outlier in the types of Convex apps out there.

The OCC write conflicts are mostly due to *bad luck*, not programming mistakes leading to extreme object churn and thus mutation starvation.due to variability and cron delays, and just chance, sometimes 3-5 mutations arrive to patch the same object within a few seconds, which causes to a bit of "retry storm" between these mutations, which leads to at least one of them to exhaust the convex-backend's default 4-retry pattern (with jitter retries in 0-100ms, 0-200ms, 0-400ms, and 0-800ms).

Therefore, it's not surprising that the patch that I did (with a single mutation retry after 5 original attempts failed within the first mutation try) helped to prevent mutation failures (which could lead to app liveness issues, failures to store durably certain critical data, etc.) so universally.

I'm not sure what's the motivation for such (relatively tight) retry delays within convex-backend. If they are absolutely arbitrary and don't interact with convex-backend's own requirements (such as mutations being 'live of retrying' for a rather tight period of time, where difference between ~1.5s and ~5s could be significant), I would say these delays should be increased x2, and perhaps the total number of retries bumped from 4 to 6, while the latter two retries still jitter in 0-1.5s, as well as the 4th retry.

If the retry policy within convex-backend is a sensitive matter that should better not be touched, I'd argue that this PR (adding one retry with 2000ms delay by default, configurable per mutation, recapitulating the patch that I did to convex-js and am running in production) is a better default behaviour for most convex apps.

### This PR

This PR is written by AI agent mostly for illustration and specificity of what I mean (and that other people may create their own patches off it if convex devs choose not to implement something like this in convex-js). I don't strictly vouch for the code. Also perhaps the defaults (one retry, 2000ms delay) should themselves be configurable via convex settings, but I didn't add code for that. I didn't add jitter to the delay between mutation retries because the write conflict retries within the convex-backend themselves add sufficient variability to the mutation duration.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
