### PR TITLE
cli: fix codegen emitting OS-dependent module order (paths sorted before separator normalization)

### DIFF
--- a/src/cli/codegen_templates/common.test.ts
+++ b/src/cli/codegen_templates/common.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "vitest";
+import { compareModulePaths } from "./common.js";
+
+describe("compareModulePaths", () => {
+  test("matches default sort order for forward slash paths", () => {
+    const paths = ["fooBaz.ts", "foo/bar.ts", "foo.ts"];
+    expect([...paths].sort(compareModulePaths)).toEqual([...paths].sort());
+  });
+
+  test("orders Windows paths identically to their POSIX equivalents", () => {
+    const posixPaths = ["fooBaz.ts", "foo/bar.ts", "foo.ts"];
+    const windowsPaths = posixPaths.map((p) => p.replace(/\//g, "\\"));
+
+    const sortedPosix = [...posixPaths].sort(compareModulePaths);
+    const sortedWindows = [...windowsPaths].sort(compareModulePaths);
+
+    expect(sortedPosix).toEqual(["foo.ts", "foo/bar.ts", "fooBaz.ts"]);
+    expect(sortedWindows.map((p) => p.replace(/\\/g, "/"))).toEqual(
+      sortedPosix,
+    );
+  });
+
+  test("default sort diverges on this input, demonstrating the bug", () => {
+    // "/" (0x2F) sorts before letters while "\" (0x5C) sorts after them,
+    // so the OS-native forms of the same file set sort differently.
+    const windowsPaths = ["fooBaz.ts", "foo\\bar.ts", "foo.ts"];
+    expect([...windowsPaths].sort()).toEqual([
+      "foo.ts",
+      "fooBaz.ts",
+      "foo\\bar.ts",
+    ]);
+    expect([...windowsPaths].sort(compareModulePaths)).toEqual([
+      "foo.ts",
+      "foo\\bar.ts",
+      "fooBaz.ts",
+    ]);
+  });
+
+  test("sorts nested directories before longer sibling file names", () => {
+    const paths = ["a/b/c.ts", "aZ.ts", "a.ts", "a/b.ts"];
+    expect([...paths].sort(compareModulePaths)).toEqual([
+      "a.ts",
+      "a/b.ts",
+      "a/b/c.ts",
+      "aZ.ts",
+    ]);
+    const windows = paths.map((p) => p.replace(/\//g, "\\"));
+    expect(
+      [...windows].sort(compareModulePaths).map((p) => p.replace(/\\/g, "/")),
+    ).toEqual(["a.ts", "a/b.ts", "a/b/c.ts", "aZ.ts"]);
+  });
+});

--- a/src/cli/codegen_templates/common.ts
+++ b/src/cli/codegen_templates/common.ts
@@ -43,3 +43,20 @@ const collator = new Intl.Collator("en-US", {
 export function compareStrings(a: string, b: string): number {
   return collator.compare(a, b);
 }
+
+/**
+ * Comparison function for sorting module paths in codegen output.
+ *
+ * Compares the forward slash normalized form of each path so the resulting
+ * order is identical on every platform. Sorting OS-native paths directly
+ * diverges on Windows because "\" (0x5C) sorts after letters while "/"
+ * (0x2F) sorts before them. Uses plain code unit comparison to match the
+ * default Array.prototype.sort() order these paths sorted with on POSIX.
+ *
+ * Usage: modulePaths.sort(compareModulePaths)
+ */
+export function compareModulePaths(a: string, b: string): number {
+  const aNormalized = a.replace(/\\/g, "/");
+  const bNormalized = b.replace(/\\/g, "/");
+  return aNormalized < bNormalized ? -1 : aNormalized > bNormalized ? 1 : 0;
+}

--- a/src/cli/codegen_templates/component_api.ts
+++ b/src/cli/codegen_templates/component_api.ts
@@ -9,7 +9,12 @@ import {
 } from "../lib/components/definition/directoryStructure.js";
 import { StartPushResponse } from "../lib/deployApi/startPush.js";
 import { importPath, moduleIdentifier } from "./api.js";
-import { apiComment, compareStrings, header } from "./common.js";
+import {
+  apiComment,
+  compareModulePaths,
+  compareStrings,
+  header,
+} from "./common.js";
 import {
   ComponentExports,
   EvaluatedComponentDefinition,
@@ -346,7 +351,7 @@ async function* codegenDynamicApiObjects(
   const absModulePaths = await entryPoints(ctx, componentDirectory.path);
   const modulePaths = absModulePaths
     .map((p) => path.relative(componentDirectory.path, p))
-    .sort();
+    .sort(compareModulePaths);
   for (const modulePath of modulePaths) {
     const ident = moduleIdentifier(modulePath);
     const path = importPath(modulePath);
@@ -382,7 +387,7 @@ async function* codegenDynamicApiObjectsTS(
   const absModulePaths = await entryPoints(ctx, componentDirectory.path);
   const modulePaths = absModulePaths
     .map((p) => path.relative(componentDirectory.path, p))
-    .sort();
+    .sort(compareModulePaths);
   for (const modulePath of modulePaths) {
     const ident = moduleIdentifier(modulePath);
     const path = importPath(modulePath);

--- a/src/cli/lib/codegen.ts
+++ b/src/cli/lib/codegen.ts
@@ -4,6 +4,7 @@ import { withTmpDir, TempDir } from "../../bundler/fs.js";
 import { entryPoints } from "../../bundler/index.js";
 import { apiCodegen } from "../codegen_templates/api.js";
 import { apiCjsCodegen } from "../codegen_templates/api_cjs.js";
+import { compareModulePaths } from "../codegen_templates/common.js";
 import {
   dynamicDataModelDTS,
   dynamicDataModelTS,
@@ -846,7 +847,7 @@ async function doApiCodegen(
   const absModulePaths = await entryPoints(ctx, functionsDir);
   const modulePaths = absModulePaths
     .map((p) => path.relative(functionsDir, p))
-    .sort();
+    .sort(compareModulePaths);
 
   const writtenFiles: string[] = [];
 


### PR DESCRIPTION
Fixes #173.

Codegen sorts module paths in their OS-native form before the separators get normalized, so the generated api files come out in a different order on Windows than on macOS/Linux. Full writeup with the repro is in the issue.

This adds `compareModulePaths` to `codegen_templates/common.ts`. It compares the forward slash normalized form of each path using plain code unit comparison. That is exactly the order these paths already sorted with on POSIX, so files generated on macOS/Linux come out byte for byte identical; Windows output now matches them.

Applied at the three places that sorted native relative paths:

- `doApiCodegen` in `src/cli/lib/codegen.ts`
- `codegenDynamicApiObjects` and `codegenDynamicApiObjectsTS` in `src/cli/codegen_templates/component_api.ts`

I went through the other sorts under `src/cli` and they all operate on separator-free strings (tool names, table names, identifiers, server-side component paths). `consistentPathSort` in the bundler sorts per-directory entry names, so that one is fine as is.

One deliberate choice: I didn't reuse the existing `compareStrings` here because the collator's order differs from plain code unit order, and switching to it would reshuffle api files already committed by POSIX users. The point of this fix is to converge on the order most existing files already have.

Testing: unit test on the comparator covering both separator forms of the repro trio, plus running codegen from source on Windows against a project containing `foo.ts` / `foo/bar.ts` / `fooBaz.ts` and confirming the generated `api.d.ts` imports and `fullApi` keys come out in POSIX order. Typecheck and lint pass.
