### PR TITLE
cli: find stable TypeScript 7 in side-by-side installs

### DIFF
--- a/src/cli/lib/typecheck.test.ts
+++ b/src/cli/lib/typecheck.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import path from "path";
+import { findTypeScriptCompilerPath } from "./typecheck.js";
+import type { TypescriptCompiler } from "./typecheck.js";
+
+const compilerPaths = {
+  tsc: path.join("node_modules", "typescript", "bin", "tsc"),
+  native: path.join("node_modules", "@typescript", "native", "bin", "tsc"),
+  tsgo: path.join(
+    "node_modules",
+    "@typescript",
+    "native-preview",
+    "bin",
+    "tsgo",
+  ),
+  legacyTsgo: path.join(
+    "node_modules",
+    "@typescript",
+    "native-preview",
+    "bin",
+    "tsgo.js",
+  ),
+} as const;
+
+describe("findTypeScriptCompilerPath", () => {
+  test.each<{
+    compiler: TypescriptCompiler;
+    existing: string[];
+    expected: string | undefined;
+  }>([
+    {
+      compiler: "tsc",
+      existing: [compilerPaths.tsc],
+      expected: compilerPaths.tsc,
+    },
+    {
+      compiler: "tsc",
+      existing: [compilerPaths.native],
+      expected: compilerPaths.native,
+    },
+    {
+      compiler: "tsc",
+      existing: [compilerPaths.tsc, compilerPaths.native],
+      expected: compilerPaths.native,
+    },
+    {
+      compiler: "tsgo",
+      existing: [compilerPaths.tsgo],
+      expected: compilerPaths.tsgo,
+    },
+    {
+      compiler: "tsgo",
+      existing: [compilerPaths.legacyTsgo],
+      expected: compilerPaths.legacyTsgo,
+    },
+    {
+      compiler: "tsgo",
+      existing: [compilerPaths.tsgo, compilerPaths.legacyTsgo],
+      expected: compilerPaths.tsgo,
+    },
+    { compiler: "tsc", existing: [], expected: undefined },
+    { compiler: "tsgo", existing: [], expected: undefined },
+  ])("finds $expected for $compiler", ({ compiler, existing, expected }) => {
+    expect(
+      findTypeScriptCompilerPath(
+        { exists: (candidate) => existing.includes(candidate) },
+        compiler,
+      ),
+    ).toBe(expected);
+  });
+});

--- a/src/cli/lib/typecheck.ts
+++ b/src/cli/lib/typecheck.ts
@@ -2,6 +2,7 @@ import { chalkStderr } from "chalk";
 import path from "path";
 import { performance } from "perf_hooks";
 import { Context } from "../../bundler/context.js";
+import type { Filesystem } from "../../bundler/fs.js";
 import {
   changeSpinner,
   logError,
@@ -139,33 +140,7 @@ async function runTsc(
   tscArgs: string[],
   handleResult: TypecheckResultHandler,
 ): Promise<void> {
-  // Check if the TypeScript compiler is even installed
-  let compilerPath: string | undefined;
-  switch (typescriptCompiler) {
-    case "tsgo": {
-      // @typescript/native-preview@7.0.0-dev.20260626.1 switched to using `bin/tsgo` instead of `bin/tsgo.js`.
-      const tsgoPaths = ["tsgo", "tsgo.js"].map((filename) =>
-        path.join(
-          "node_modules",
-          "@typescript",
-          "native-preview",
-          "bin",
-          filename,
-        ),
-      );
-      compilerPath = tsgoPaths.find((path) => ctx.fs.exists(path));
-      break;
-    }
-    case "tsc": {
-      const tscPath = path.join("node_modules", "typescript", "bin", "tsc");
-      if (ctx.fs.exists(tscPath)) {
-        compilerPath = tscPath;
-      }
-      break;
-    }
-    default:
-      typescriptCompiler satisfies never;
-  }
+  const compilerPath = findTypeScriptCompilerPath(ctx.fs, typescriptCompiler);
   if (!compilerPath) {
     return handleResult("cantTypeCheck", () => {
       logError(
@@ -194,6 +169,37 @@ async function runTsc(
         "Convex works best with TypeScript version 4.8.4 or newer -- npm i --save-dev typescript@latest to update.",
       ),
     );
+  }
+}
+
+export function findTypeScriptCompilerPath(
+  fs: Pick<Filesystem, "exists">,
+  typescriptCompiler: TypescriptCompiler,
+): string | undefined {
+  switch (typescriptCompiler) {
+    case "tsgo": {
+      // @typescript/native-preview@7.0.0-dev.20260626.1 switched to using `bin/tsgo` instead of `bin/tsgo.js`.
+      const tsgoPaths = ["tsgo", "tsgo.js"].map((filename) =>
+        path.join(
+          "node_modules",
+          "@typescript",
+          "native-preview",
+          "bin",
+          filename,
+        ),
+      );
+      return tsgoPaths.find((path) => fs.exists(path));
+    }
+    case "tsc": {
+      const tscPaths = [
+        // TypeScript 7's recommended alias when the TypeScript 6 API is also installed.
+        path.join("node_modules", "@typescript", "native", "bin", "tsc"),
+        path.join("node_modules", "typescript", "bin", "tsc"),
+      ];
+      return tscPaths.find((path) => fs.exists(path));
+    }
+    default:
+      typescriptCompiler satisfies never;
   }
 }
 


### PR DESCRIPTION
## Summary

- Resolve `node_modules/@typescript/native/bin/tsc` when the stable TypeScript 7 alias is explicitly installed.
- Preserve `node_modules/typescript/bin/tsc` for normal TypeScript 6 and 7 installations.
- Keep `@typescript/native-preview` and `"tsgo"` behavior unchanged.
- Add focused compiler-resolution coverage.

Fixes #177.

## Why

TypeScript 7.0 does not expose the legacy JavaScript compiler API. For tools that still import it, the TypeScript team recommends installing the TypeScript 6 compatibility package under the name `typescript` and aliasing stable TypeScript 7 as `@typescript/native`:

```json
{
  "devDependencies": {
    "@typescript/native": "npm:typescript@^7.0.2",
    "typescript": "npm:@typescript/typescript6@^6.0.2"
  }
}
```

npm and Bun expose `tsc` from `@typescript/native` in this layout. Convex bypasses the project bin link and currently checks only `node_modules/typescript/bin/tsc`; the compatibility package exposes `tsc6` instead, so Convex reports that TypeScript is not installed.

The CLI intentionally invokes compiler JavaScript entry points through Node rather than executing `node_modules/.bin` wrappers. This change preserves that approach and adds explicit resolution for the official stable alias.

When both full TypeScript 6 and aliased TypeScript 7 are installed, npm and Bun expose the alias as the project's `tsc`; this change follows that behavior. Existing TypeScript 6-only projects are unchanged because the alias is absent. The `"tsgo"` selection remains associated with `@typescript/native-preview` for backward compatibility.

`typescriptCompiler` is already optional and defaults to `"tsc"`. Stable TypeScript 7 works through that default; this PR does not add another compiler setting or remove the existing preview escape hatch.

## Verification

- Focused compiler-resolution tests, including precedence and both preview entry names
- Repository typecheck and build
- Public format and lint checks
- Built CLI against normal `typescript@7.0.2`: passes
- Built CLI against the npm and Bun side-by-side layouts: passes
- Full TypeScript 6 + aliased stable TypeScript 7: selects TS7, matching npm and Bun's `tsc`
- Built CLI against TypeScript 6 + `@typescript/native-preview`: passes
- Intentional stable-TS7 type error: fails with the expected diagnostic

The focused test makes the alias precedence and retained preview behavior explicit. I am happy to drop it if maintainers prefer to cover this in the internal test suite.

## Scope

This PR does not change config discovery or walk parent `node_modules` directories, and it does not resolve #153. Stable-installation documentation is covered by the companion get-convex/convex-backend#504.

By submitting pull requests, you confirm that Convex can use, modify, copy, and redistribute the contribution, under the terms of its choice.
