### PR TITLE
Expose a typed validatorToJson helper

### DIFF
--- a/src/values/index.ts
+++ b/src/values/index.ts
@@ -13,7 +13,7 @@ export type {
   Value,
   NumericValue,
 } from "./value.js";
-export { v, asObjectValidator } from "./validator.js";
+export { v, asObjectValidator, validatorToJson } from "./validator.js";
 export type {
   AsObjectValidator,
   GenericValidator,

--- a/src/values/validator.ts
+++ b/src/values/validator.ts
@@ -18,6 +18,7 @@ import {
   VString,
   VUnion,
   Validator,
+  type ValidatorJSON,
 } from "./validators.js";
 
 /**
@@ -67,6 +68,21 @@ export type AsObjectValidator<
     : V extends PropertyValidators
       ? Validator<ObjectType<V>>
       : never;
+
+/**
+ * Return the JSON representation of a Convex validator.
+ *
+ * This is useful for schema introspection, form generation, and other tooling
+ * that needs the complete validator shape rather than only its `kind`.
+ *
+ * @param validator - The validator to serialize.
+ * @returns The validator's JSON representation.
+ *
+ * @public
+ */
+export function validatorToJson(validator: GenericValidator): ValidatorJSON {
+  return validator.json;
+}
 
 /**
  * The validator builder.


### PR DESCRIPTION
## Summary

- Export `validatorToJson` from `convex/values`.
- Return the existing `ValidatorJSON` representation while keeping the validator `.json` property internal.

Fixes #128.

## Why

Validators already expose their complete JSON representation internally, but callers currently need an unsafe cast to access it. A small function provides a stable typed boundary without making the implementation property public on every validator type.

## New API

```ts
import { v, validatorToJson } from "convex/values";

const validator = v.union(v.literal("pending"), v.literal("done"));
const json = validatorToJson(validator); // ValidatorJSON
```

## Compatibility

This is additive. Existing validator types and runtime behavior are unchanged, and `.json` remains internal.

## Verification

- `npm run typecheck`
- `npm run build`
- `npm run test-esm`
- Targeted ESLint and `git diff --check`
- Verified the helper in the generated ESM/CJS declarations and built exports
- Verified union/literal serialization against the built ESM package

`npm test` was also attempted; this public checkout currently contains no test files, so Vitest exits with `No test files found`.

## Scope

This only adds the typed serialization boundary. It does not expose `.json` directly or add schema traversal helpers.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
