### PR TITLE
schema.doc types omit system fields in nested unions

### DIFF
--- a/src/server/schema.test.ts
+++ b/src/server/schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { type Infer, v } from "../values/index.js";
+import type { DocumentByName } from "./data_model.js";
+import {
+  type DataModelFromSchemaDefinition,
+  defineSchema,
+  defineTable,
+} from "./schema.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Value extends true> = Value;
+
+const innerResult = v.union(
+  v.object({ kind: v.literal("success"), value: v.string() }),
+  v.object({ kind: v.literal("error"), message: v.string() }),
+);
+
+const schema = defineSchema({
+  results: defineTable(
+    v.union(
+      innerResult,
+      v.object({ kind: v.literal("pending"), startedAt: v.number() }),
+    ),
+  ),
+});
+
+type ResultDoc = Infer<ReturnType<typeof schema.doc<"results">>>;
+type GeneratedResultDoc = DocumentByName<
+  DataModelFromSchemaDefinition<typeof schema>,
+  "results"
+>;
+type ResultDocMatchesGeneratedDataModel = Expect<
+  Equal<ResultDoc, GeneratedResultDoc>
+>;
+
+describe("schema.doc", () => {
+  test("adds system fields to objects in nested unions", () => {
+    const resultDoc = schema.doc("results");
+
+    expect(resultDoc.kind).toBe("union");
+    expect(resultDoc.members[0].kind).toBe("union");
+    for (const member of resultDoc.members[0].members) {
+      expect(member.kind).toBe("object");
+      expect(Object.keys(member.fields)).toEqual(
+        expect.arrayContaining(["_id", "_creationTime"]),
+      );
+    }
+  });
+});
+
+void (false as ResultDocMatchesGeneratedDataModel);

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -675,19 +675,31 @@ export type SystemFieldValidators<TableName extends string> = {
 };
 
 /**
- * Add the system field validators to an object validator, leaving any other
- * validator untouched.
+ * Add the system field validators to every object validator in a document
+ * validator, including objects in nested unions.
  */
 type WithSystemFieldValidators<
   TableName extends string,
   DocumentType extends Validator<any, any, any>,
-> =
-  DocumentType extends VObject<infer Type, infer Fields, any, any>
+> = 0 extends 1 & DocumentType
+  ? DocumentType
+  : DocumentType extends VObject<infer Type, infer Fields, any, any>
     ? VObject<
         Expand<IdField<TableName> & SystemFields & Type>,
         Expand<SystemFieldValidators<TableName> & Fields>
       >
-    : DocumentType;
+    : DocumentType extends VUnion<any, infer Members, any, any>
+      ? Validator<any, "required", any>[] extends Members
+        ? DocumentType
+        : {
+              [Index in keyof Members]: WithSystemFieldValidators<
+                TableName,
+                Members[Index]
+              >;
+            } extends infer NewMembers extends Validator<any, "required", any>[]
+          ? VUnion<NewMembers[number]["type"], NewMembers>
+          : never
+      : DocumentType;
 
 /**
  * The validator for whole documents of a table: the table's own validator with
@@ -701,20 +713,7 @@ type WithSystemFieldValidators<
 export type DocValidator<
   TableName extends string,
   DocumentType extends Validator<any, any, any>,
-> =
-  DocumentType extends VUnion<any, infer Members, any, any>
-    ? {
-        [Index in keyof Members]: WithSystemFieldValidators<
-          TableName,
-          Members[Index]
-        >;
-      } extends infer NewMembers extends Validator<any, "required", any>[]
-      ? VUnion<
-          WithSystemFieldValidators<TableName, Members[number]>["type"],
-          NewMembers
-        >
-      : never
-    : WithSystemFieldValidators<TableName, DocumentType>;
+> = WithSystemFieldValidators<TableName, DocumentType>;
 
 function addSystemFields(
   tableName: string,
@@ -772,11 +771,12 @@ export function docValidator<
 >(
   tableName: TableName,
   table: Table,
-): DocValidator<TableName, Table["validator"]> {
-  return addSystemFields(tableName, table.validator) as DocValidator<
-    TableName,
-    Table["validator"]
-  >;
+): DocValidator<TableName, Table["validator"]>;
+export function docValidator(
+  tableName: string,
+  table: TableDefinition,
+): GenericValidator {
+  return addSystemFields(tableName, table.validator);
 }
 
 /**
@@ -848,8 +848,9 @@ export class SchemaDefinition<
    */
   doc<TableName extends keyof Schema & string>(
     tableName: TableName,
-  ): DocValidator<TableName, Schema[TableName]["validator"]> {
-    return docValidator(tableName, tableInSchema(this, tableName));
+  ): DocValidator<TableName, Schema[TableName]["validator"]>;
+  doc(tableName: keyof Schema & string): GenericValidator {
+    return addSystemFields(tableName, tableInSchema(this, tableName).validator);
   }
 
   /**


### PR DESCRIPTION
Nested union members returned from `schema.doc()` and `docValidator()` have the wrong inferred type. Runtime validation recursively adds `_id` and `_creationTime`, but the type-level transformation stops after the first union, so inner union branches omit both fields.

This makes the inferred return type disagree with the generated data model and with what the validator accepts.

This change recursively transforms concrete union members. The `Validator[]` guard leaves broad generic validator arrays unchanged, avoiding excessive TypeScript instantiation.

Added a nested-union regression test.

Verified with:
- `npm run typecheck`
- `npm test -- --run`
- `npx eslint src/server/schema.ts src/server/schema.test.ts`