### PR TITLE
Export PatchValue from convex/server

### DIFF
--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -266,7 +266,7 @@ export interface GenericDatabaseWriter<
    *
    * @param table - The name of the table the document is in.
    * @param id - The {@link values.GenericId} of the document to patch.
-   * @param value - The partial document to merge into the existing document.
+   * @param value - The {@link PatchValue} to merge into the existing document.
    */
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
@@ -288,7 +288,7 @@ export interface GenericDatabaseWriter<
    * in new code.
    *
    * @param id - The {@link values.GenericId} of the document to patch.
-   * @param value - The partial document to merge into the existing document.
+   * @param value - The {@link PatchValue} to merge into the existing document.
    */
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     id: GenericId<TableName>,
@@ -434,7 +434,7 @@ export interface BaseTableWriter<
    * `undefined` are removed.
    *
    * @param id - The {@link values.GenericId} of the document to patch.
-   * @param value - The partial {@link GenericDocument} to merge into the specified document. If this new value
+   * @param value - The {@link PatchValue} to merge into the specified document. If this new value
    * specifies system fields like `_id`, they must match the document's existing field values.
    */
   patch(
@@ -471,9 +471,26 @@ type NonUnion<T> = T extends never // `never` is the bottom type for TypeScript 
   : T;
 
 /**
- * This is like Partial, but it also allows undefined to be passed to optional
- * fields when `exactOptionalPropertyTypes` is enabled in the tsconfig.
+ * The type of the value argument to {@link GenericDatabaseWriter.patch}.
+ *
+ * This is like `Partial<T>`, but it also allows `undefined` to be passed to
+ * optional fields when `exactOptionalPropertyTypes` is enabled in the
+ * tsconfig. Fields set to `undefined` are removed; omitted fields are left
+ * unchanged.
+ *
+ * `db.patch` applies this to the full document, including system fields. If
+ * `_id` or `_creationTime` are specified they must match the existing
+ * document. To type a patch object that cannot include system fields:
+ *
+ * ```ts
+ * import type { PatchValue, WithoutSystemFields } from "convex/server";
+ * import type { Doc } from "./_generated/dataModel";
+ *
+ * type TaskPatch = PatchValue<WithoutSystemFields<Doc<"tasks">>>;
+ * ```
+ *
+ * @public
  */
-type PatchValue<T> = {
+export type PatchValue<T> = {
   [P in keyof T]?: undefined extends T[P] ? T[P] | undefined : T[P];
 };


### PR DESCRIPTION
## Summary

- Export `PatchValue` from `convex/server`. This is already the type of the value argument to `db.patch`, and it already appears in the public API docs, but it was not importable.
- Insert and replace already export `WithoutSystemFields` and `WithOptionalSystemFields`; patch was the missing third.

## Why

Callers that accumulate a patch object before `ctx.db.patch` currently copy the private mapped type (Convex's own `convex-helpers` triggers writer does this too). `Partial<Doc<T>>` is not enough when `exactOptionalPropertyTypes` is on, because `undefined` is how `db.patch` deletes optional fields.

```ts
import type { PatchValue, WithoutSystemFields } from "convex/server";
import type { Doc } from "./_generated/dataModel";

type TaskPatch = PatchValue<WithoutSystemFields<Doc<"tasks">>>;
```

`db.patch` still applies `PatchValue` to the full document, including system fields. This PR does not change that contract.

## Compatibility

Additive. Runtime behavior is unchanged. The mapped type is identical; it is now `export type` with `@public`.

## Verification

- Source-only change in `src/server/database.ts`. `export * from "./database.js"` already re-exports it from `convex/server`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Made with [Cursor](https://cursor.com)